### PR TITLE
Modified the default route behavior to use DMS

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -318,7 +318,7 @@ func addSnitchSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.
 	}
 
 	// Overwrite the existing Watchdog config with the updated version specified above.
-	// This keeps other receivers intact while updating only the Watchdog receiver.
+	// This keeps other receivers intact while updating only the Watchdog related receivers.
 	watchdogabsent := true
 	for i, receiver := range amconfig.Receivers {
 		log.Info("DEBUG: Found Receiver named:", receiver.Name)
@@ -326,8 +326,10 @@ func addSnitchSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.
 			log.Info("DEBUG: Overwriting watchdog receiver:", receiver.Name)
 			amconfig.Receivers[i].WebhookConfigs = []*alertmanager.WebhookConfig{snitchconfig}
 			watchdogabsent = false
-		} else {
-			log.Info("DEBUG: Skipping Receiver named", receiver.Name)
+		} else if receiver.Name == "null" {
+			// Delete the default 'null' Receiver, because watchdog will become the new default.
+			log.Info("DEBUG: Deleting receiver named:", receiver.Name)
+			amconfig.Receivers = removeFromReceivers(amconfig.Receivers, i)
 		}
 	}
 
@@ -356,8 +358,10 @@ func addSnitchSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.
 			log.Info("DEBUG: Overwriting Watchdog Route for Receiver:", route.Receiver)
 			amconfig.Route.Routes[i] = wdroute
 			routeabsent = false
-		} else {
-			log.Info("DEBUG: Skipping Route for Receiver named", route.Receiver)
+		} else if route.Receiver == "null" {
+			// Remove null route, since the watchdog route replaces it.
+			log.Info("DEBUG: Deleting Route for Receiver:", route.Receiver)
+			amconfig.Route.Routes = removeFromRoutes(amconfig.Route.Routes, i)
 		}
 	}
 
@@ -366,6 +370,10 @@ func addSnitchSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.
 		log.Info("DEBUG: Route for Watchdog Receiver is absent. Creating new Route.")
 		amconfig.Route.Routes = append(amconfig.Route.Routes, wdroute)
 	}
+
+	// Update the default route to point to our new receiver.
+	amconfig.Route.Receiver = "watchdog"
+
 }
 
 // removeFromReceivers removes the specified index from a slice of Receivers.
@@ -390,11 +398,22 @@ func removeConfigFromAlertManager(r *ReconcileSecret, request *reconcile.Request
 			amconfig.Receivers = removeFromReceivers(amconfig.Receivers, i)
 		}
 	}
-
 	for i, route := range amconfig.Route.Routes {
 		if route.Receiver == receivername {
 			log.Info("DEBUG: Deleting Route for Receiver:", route.Receiver)
 			amconfig.Route.Routes = removeFromRoutes(amconfig.Route.Routes, i)
 		}
+	}
+
+	// If watchdog is being removed, put the system default route and receiver back into place.
+	if receivername == "watchdog" {
+		amconfig.Route.Receiver = "null"
+		nullroute := &alertmanager.Route{
+			Receiver: "null",
+			Match:    map[string]string{"alertname": "Watchdog"},
+		}
+		amconfig.Route.Routes = append(amconfig.Route.Routes, nullroute)
+		nullreceiver := &alertmanager.Receiver{Name: "null"}
+		amconfig.Receivers = append(amconfig.Receivers, nullreceiver)
 	}
 }


### PR DESCRIPTION
The default route in Alertmanager is set to "null" at install time. This commit modifies the behavior of configure-alertmanager-operator to set the default route to "watchdog", so that our receiver will be used to send responses to DMS by default. When the DMS secret is deleted, the Alertmanager default "null" route is restored.

This fixes: https://github.com/openshift/configure-alertmanager-operator/issues/7