### PR TITLE
Add tests for secret controller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -74,6 +74,14 @@
   version = "v2.9.0"
 
 [[projects]]
+  digest = "1:820227d03dc661d34f837f3704626d2837dbfbf9f0ec8fdf1f58e683dc5f56fc"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
+  version = "v4.1.0"
+
+[[projects]]
   digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -745,6 +753,7 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "testing",
     "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
@@ -851,6 +860,7 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller",
     "pkg/event",
     "pkg/handler",
@@ -916,6 +926,7 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
@@ -927,6 +938,7 @@
     "k8s.io/kube-openapi/cmd/openapi-gen",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller",
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -88,7 +88,7 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 
 	// This block looks at a specific instance of Secret. This is done for each Secret
 	// in the `openshift-monitoring` namespace. In the case of a deleted Secret,
-	// the associated Alertmanager config is removed.
+	// the Alertmanager config associated with that Secret is removed.
 	instance := &corev1.Secret{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -74,6 +74,18 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 	log.Info("DEBUG: Started reconcile loop")
 
+	// Get a list of all Secrets in the `openshift-monitoring` namespace.
+	// This is used for determining which secrets are present so that the necessary
+	// Alertmanager config changes can happen later.
+	secretList := &corev1.SecretList{}
+	opts := client.ListOptions{Namespace: request.Namespace}
+	r.client.List(context.TODO(), &opts, secretList)
+
+	// Check for the presence of specific secrets.
+	pagerDutySecretExists := secretInList("pd-secret", secretList)
+	snitchSecretExists := secretInList("dms-secret", secretList)
+	alertmanagerSecretExists := secretInList("alertmanager-main", secretList)
+
 	// This block looks at a specific instance of Secret. This is done for each Secret
 	// in the `openshift-monitoring` namespace. In the case of a deleted Secret,
 	// the associated Alertmanager config is removed.
@@ -82,6 +94,10 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("INFO: This secret has been deleted:", request.Name)
+			if !alertmanagerSecretExists {
+				log.Info("Alertmanager secret does not exist! Unable to modify Alertmanager config. Requeuing")
+				return reconcile.Result{}, nil
+			}
 			if request.Name == "pd-secret" {
 				log.Info("INFO: Pager Duty secret is absent. Removing Pager Duty config from Alertmanager")
 				alertmanagerconfig := getAlertManagerConfig(r, &request)
@@ -102,18 +118,6 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 			return reconcile.Result{}, nil
 		}
 	}
-
-	// Get a list of all Secrets in the `openshift-monitoring` namespace.
-	// This is used for determining which secrets are present so that the necessary
-	// Alertmanager config changes can happen later.
-	secretList := &corev1.SecretList{}
-	opts := client.ListOptions{Namespace: request.Namespace}
-	r.client.List(context.TODO(), &opts, secretList)
-
-	// Check for the presence of specific secrets.
-	pagerDutySecretExists := secretInList("pd-secret", secretList)
-	snitchSecretExists := secretInList("dms-secret", secretList)
-	alertmanagerSecretExists := secretInList("alertmanager-main", secretList)
 
 	// Extract the alertmanager config from the alertmanager-main secret.
 	// If it doesn't exist yet, requeue this request and try again later.

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -1,0 +1,376 @@
+package secret
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/configure-alertmanager-operator/config"
+	alertmanager "github.com/openshift/configure-alertmanager-operator/pkg/types"
+	yaml "gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// AlertManager base config, used by multiple tests.
+const AlertManagerConfig = `
+global:
+  resolve_timeout: 5m
+route:
+  receiver: "null"
+  group_by:
+  - job
+  routes:
+  - receiver: "null"
+    match:
+      alertname: Watchdog
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+receivers:
+- name: "null"
+templates: []
+`
+
+// createAlertManagerConfig creates a fake secret containing a basic AlertManager config for testing.
+func createAlertManagerConfig(amconfig []byte, reconciler *ReconcileSecret) {
+	amsecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alertmanager-main",
+			Namespace: config.OperatorNamespace,
+		},
+		Data: map[string][]byte{
+			"alertmanager.yaml": []byte(amconfig),
+		},
+	}
+	reconciler.client.Create(context.TODO(), amsecret)
+}
+
+// createSecret creates a fake Secret to use in testing.
+func createSecret(secretname string, secretkey string, secretdata string, reconciler *ReconcileSecret) {
+	newsecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretname,
+			Namespace: config.OperatorNamespace,
+		},
+		Data: map[string][]byte{
+			secretkey: []byte(secretdata),
+		},
+	}
+	reconciler.client.Create(context.TODO(), newsecret)
+}
+
+// createReconciler creates a fake ReconcileSecret for testing.
+func createReconciler() *ReconcileSecret {
+	return &ReconcileSecret{
+		client: fake.NewFakeClient(),
+		scheme: nil,
+	}
+}
+
+// createNamespace creates a fake `openshift-monitoring` namespace for testing.
+func createNamespace(reconciler *ReconcileSecret, t *testing.T) {
+	err := reconciler.client.Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: config.OperatorNamespace}})
+	if err != nil {
+		// exit the test if we can't create the namespace. Every test depends on this.
+		t.Errorf("Couldn't create the required namespace for the test. Encountered error: %s", err)
+		panic("Exiting due to fatal error")
+	}
+}
+
+// Create the reconcile request for the specified secret.
+func createReconcileRequest(reconciler *ReconcileSecret, secretname string) *reconcile.Request {
+	return &reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      secretname,
+			Namespace: config.OperatorNamespace,
+		},
+	}
+}
+
+// Test_getAlertManagerConfig ensures that the default AlertManagerConfig is the same after marshalling and unmarshalling.
+// If this test fails, all other tests will fail, because it's crucial to be able to retrieve
+// the alertmanager config when testing functions that read and write the alertmanager config.
+func Test_getAlertManagerConfig(t *testing.T) {
+
+	// This stores the Config object to test against.
+	// It should be equal to the object created by getAlertManagerConfig.
+	want := alertmanager.Config{}
+
+	// Mock cluster data, including alertmanager-main secret, namespace, and reconcile request.
+
+	amconfigbyte := []byte(AlertManagerConfig)
+	reconciler := createReconciler()
+	createNamespace(reconciler, t)
+	createAlertManagerConfig(amconfigbyte, reconciler)
+	req := createReconcileRequest(reconciler, "alertmanager-main")
+
+	// Marshal the []byte into an alertmanager.Config object.
+	err := yaml.Unmarshal(amconfigbyte, &want)
+	if err != nil {
+		t.Errorf("Unable to Unmarshal []byte into alertmanager.Config type")
+		panic("Unable to continue test due to unmarshal error.")
+	}
+
+	if got := getAlertManagerConfig(reconciler, req); !reflect.DeepEqual(got, want) {
+		t.Errorf("Failed because getAlertManagerConfig() returned:\n%s\n getAlertManagerConfig() should have returned:\n%s\n", got, want)
+	} else {
+		t.Logf("Passed, using default config. getAlertManagerConfig() returned:\n%s\n", got)
+	}
+}
+
+// Test_updateAlertManagerConfig tests writing to the Alertmanager config.
+func Test_updateAlertManagerConfig(t *testing.T) {
+
+	// Load the default AlertManager config into the fake cluster.
+	amconfigbyte := []byte(AlertManagerConfig)
+	reconciler := createReconciler()
+	createNamespace(reconciler, t)
+	createAlertManagerConfig(amconfigbyte, reconciler)
+	req := createReconcileRequest(reconciler, "alertmanager-main")
+	amconfig := getAlertManagerConfig(reconciler, req)
+	// This needs to be a copy, or else it just points to amconfig
+	defaultconfig := getAlertManagerConfig(reconciler, req)
+
+	// Update the Alertmanager config.
+	amconfig.Route.GroupWait = "10s"
+	updateAlertManagerConfig(reconciler, req, &amconfig)
+
+	// Test that the change is present.
+	if got := getAlertManagerConfig(reconciler, req); reflect.DeepEqual(got, defaultconfig) {
+		t.Errorf("Failed because getAlertManagerConfig() shows equal results before and after writing the config")
+		t.Errorf("getAlertManagerConfig() before the write:\n%s\ngetAlertManagerConfig() after the write:\n%s\n", defaultconfig, got)
+		t.Errorf("Field 'group_wait' was not updated as expected")
+	} else {
+		t.Logf("Passed, modified 'group_wait' in default config. getAlertManagerConfig() returned:\n%s\n", got)
+	}
+}
+
+// Test_addPDSecretToAlertManagerConfig tests the integration
+// of 3 functions that combine to update the Pager Duty config in Alertmanager:
+// getAlertManagerConfig, updateAlertManagerConfig, and addPDSecretToAlertManagerConfig.
+func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
+	pdsecret := "asdf1234567890"
+
+	// Load the default AlertManager config into the fake cluster.
+	amconfigbyte := []byte(AlertManagerConfig)
+	reconciler := createReconciler()
+	createNamespace(reconciler, t)
+	createSecret("pd-secret", "PAGERDUTY_KEY", pdsecret, reconciler)
+	createAlertManagerConfig(amconfigbyte, reconciler)
+	req := createReconcileRequest(reconciler, "pd-secret")
+	want := getAlertManagerConfig(reconciler, req)
+
+	// Add the Pager Duty details to the fake alertmanager config.
+	pdconfig := &alertmanager.PagerdutyConfig{
+		NotifierConfig: alertmanager.NotifierConfig{VSendResolved: true},
+		RoutingKey:     pdsecret,
+		Description:    `{{ .CommonLabels.alertname }} {{ .CommonLabels.severity | toUpper }} ({{ len .Alerts }})`,
+		Details: map[string]string{
+			"link":         `{{ .CommonAnnotations.link }}?`,
+			"group":        `{{ .CommonLabels.alertname }}`,
+			"component":    `{{ .CommonLabels.alertname }}`,
+			"num_firing":   `{{ .Alerts.Firing | len }}`,
+			"num_resolved": `{{ .Alerts.Resolved | len }}`,
+			"resolved":     `{{ template pagerduty.default.instances .Alerts.Resolved }}`,
+		},
+	}
+	pdroute := &alertmanager.Route{
+		Continue: true,
+		Receiver: "pagerduty",
+		GroupByStr: []string{
+			"alertname",
+			"severity",
+		},
+		MatchRE: map[string]string{
+			"namespace": "^openshift$|openshift-.*|default$|kube$|kube-.*|logging$",
+		},
+	}
+	pdreceiver := &alertmanager.Receiver{
+		Name:             "pagerduty",
+		PagerdutyConfigs: []*alertmanager.PagerdutyConfig{pdconfig},
+	}
+	want.Receivers = append(want.Receivers, pdreceiver)
+	want.Route.Routes = append(want.Route.Routes, pdroute)
+	want.Global.PagerdutyURL = "https://events.pagerduty.com/v2/enqueue"
+
+	// Try to get the same result as `want`,
+	// using addPDSecretToAlertManagerConfig() and updateAlertManagerConfig().
+	defaultconfig := getAlertManagerConfig(reconciler, req)
+	addPDSecretToAlertManagerConfig(reconciler, req, &defaultconfig, pdsecret)
+	updateAlertManagerConfig(reconciler, req, &defaultconfig)
+
+	// Test that the alertmanager secret now contains all the Pager Duty details,
+	// as specified in var `want`.
+	if got := getAlertManagerConfig(reconciler, req); !reflect.DeepEqual(got, want) {
+		t.Errorf("Failed because getAlertManagerConfig() returned:\n%s\n getAlertManagerConfig() should have returned:\n%s\n", got, want)
+	} else {
+		t.Logf("Passed, using Pager Duty config. getAlertManagerConfig() returned:\n%s\n", got)
+	}
+}
+
+// Test_addSnitchSecretToAlertManagerConfig tests adding the DMS secret
+// to the Alertmanager config. It also tests functions:
+// removeFromRoutes() and removeFromReceivers()
+func Test_addSnitchSecretToAlertManagerConfig(t *testing.T) {
+	// Set up fake cluster resources.
+	snitchsecret := "https://hjkl0987654"
+	reconciler := createReconciler()
+	createNamespace(reconciler, t)
+	createSecret("dms-secret", "SNITCH_URL", snitchsecret, reconciler)
+	req := createReconcileRequest(reconciler, "dms-secret")
+
+	// Load the default AlertManager config into the fake cluster.
+	amconfigbyte := []byte(AlertManagerConfig)
+	createAlertManagerConfig(amconfigbyte, reconciler)
+
+	// Build a representation of the object we want.
+	want := getAlertManagerConfig(reconciler, req)
+	snitchconfig := &alertmanager.WebhookConfig{
+		NotifierConfig: alertmanager.NotifierConfig{VSendResolved: true},
+		URL:            snitchsecret,
+	}
+
+	// Remove default "null" receiver and replace it.
+	want.Receivers = removeFromReceivers(want.Receivers, 0)
+	newreceiver := &alertmanager.Receiver{
+		Name:           "watchdog",
+		WebhookConfigs: []*alertmanager.WebhookConfig{snitchconfig},
+	}
+	want.Receivers = append(want.Receivers, newreceiver)
+
+	// Create a route for the new Watchdog receiver.
+	wdroute := &alertmanager.Route{
+		Receiver:       "watchdog",
+		RepeatInterval: "5m",
+		Match:          map[string]string{"alertname": "Watchdog"},
+	}
+	want.Route.Routes = removeFromRoutes(want.Route.Routes, 0)
+	want.Route.Routes = append(want.Route.Routes, wdroute)
+	want.Route.Receiver = "watchdog"
+
+	// Try to get the same result as `want`,
+	// using addSnitchSecretToAlertManagerConfig() and updateAlertManagerConfig().
+	defaultconfig := getAlertManagerConfig(reconciler, req)
+	addSnitchSecretToAlertManagerConfig(reconciler, req, &defaultconfig, snitchsecret)
+	updateAlertManagerConfig(reconciler, req, &defaultconfig)
+
+	// Test that the alertmanager secret now contains all the Dead Man's Snitch details,
+	// as specified in var `want`.
+	if got := getAlertManagerConfig(reconciler, req); !reflect.DeepEqual(got, want) {
+		t.Errorf("Failed because getAlertManagerConfig() returned:\n%s\n getAlertManagerConfig() should have returned:\n%s\n", got, want)
+	} else {
+		t.Logf("Passed, using Pager Duty config. getAlertManagerConfig() returned:\n%s\n", got)
+	}
+}
+
+func TestReconcileSecret_Reconcile(t *testing.T) {
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+	tests := []struct {
+		name    string
+		secret  string
+		exists  bool // Indicates if the secret being reconciled exists.
+		want    reconcile.Result
+		wantErr bool
+	}{
+		{
+			name:    "Test reconcile with dms-secret present.",
+			secret:  "dms-secret",
+			exists:  true,
+			want:    reconcile.Result{Requeue: false},
+			wantErr: false,
+		},
+		{
+			name:    "Test reconcile with dms-secret missing.",
+			secret:  "dms-secret",
+			exists:  false,
+			want:    reconcile.Result{Requeue: false},
+			wantErr: false,
+		},
+		{
+			name:    "Test reconcile with pd-secret present.",
+			secret:  "pd-secret",
+			exists:  true,
+			want:    reconcile.Result{Requeue: false},
+			wantErr: false,
+		},
+		{
+			name:    "Test reconcile with pd-secret missing.",
+			secret:  "pd-secret",
+			exists:  false,
+			want:    reconcile.Result{Requeue: false},
+			wantErr: false,
+		},
+		{
+			name:    "Test reconcile with alertmanager-main present.",
+			secret:  "alertmanager-main",
+			exists:  true,
+			want:    reconcile.Result{Requeue: false},
+			wantErr: false,
+		},
+		{
+			name:    "Test reconcile with alertmanager-main missing.",
+			secret:  "alertmanager-main",
+			exists:  false,
+			want:    reconcile.Result{Requeue: false},
+			wantErr: false,
+		},
+		{
+			name:    "Test reconcile with unreconcilable secret.",
+			secret:  "testsecret",
+			exists:  true,
+			want:    reconcile.Result{Requeue: false},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		reconciler := createReconciler()
+		createNamespace(reconciler, t)
+
+		// Create the secret for this specific test.
+		if tt.exists {
+			switch tt.secret {
+			case "pd-secret":
+				createSecret("pd-secret", "PAGERDUTY_KEY", "asdfjkl123", reconciler)
+			case "dms-secret":
+				createSecret("dms-secret", "SNITCH_URL", "https://hjklasdf09876", reconciler)
+			case "alertmanager-main":
+				amconfigbyte := []byte(AlertManagerConfig)
+				createAlertManagerConfig(amconfigbyte, reconciler)
+			default:
+				createSecret(tt.secret, "key", "asdfjkl", reconciler)
+			}
+		}
+
+		req := createReconcileRequest(reconciler, "dms-secret")
+
+		// Load the default AlertManager config into the fake cluster.
+		if tt.secret != "alertmanager-main" {
+			amconfigbyte := []byte(AlertManagerConfig)
+			createAlertManagerConfig(amconfigbyte, reconciler)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileSecret{
+				client: fake.NewFakeClient(),
+				scheme: nil,
+			}
+			got, err := r.Reconcile(*req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileSecret.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileSecret.Reconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/vendor/github.com/evanphx/json-patch/LICENSE
+++ b/vendor/github.com/evanphx/json-patch/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/evanphx/json-patch/cmd/json-patch/file_flag.go
+++ b/vendor/github.com/evanphx/json-patch/cmd/json-patch/file_flag.go
@@ -1,0 +1,39 @@
+package main
+
+// Borrowed from Concourse: https://github.com/concourse/atc/blob/master/atccmd/file_flag.go
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FileFlag is a flag for passing a path to a file on disk. The file is
+// expected to be a file, not a directory, that actually exists.
+type FileFlag string
+
+// UnmarshalFlag implements go-flag's Unmarshaler interface
+func (f *FileFlag) UnmarshalFlag(value string) error {
+	stat, err := os.Stat(value)
+	if err != nil {
+		return err
+	}
+
+	if stat.IsDir() {
+		return fmt.Errorf("path '%s' is a directory, not a file", value)
+	}
+
+	abs, err := filepath.Abs(value)
+	if err != nil {
+		return err
+	}
+
+	*f = FileFlag(abs)
+
+	return nil
+}
+
+// Path is the path to the file
+func (f FileFlag) Path() string {
+	return string(f)
+}

--- a/vendor/github.com/evanphx/json-patch/cmd/json-patch/main.go
+++ b/vendor/github.com/evanphx/json-patch/cmd/json-patch/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type opts struct {
+	PatchFilePaths []FileFlag `long:"patch-file" short:"p" value-name:"PATH" description:"Path to file with one or more operations"`
+}
+
+func main() {
+	var o opts
+	_, err := flags.Parse(&o)
+	if err != nil {
+		log.Fatalf("error: %s\n", err)
+	}
+
+	patches := make([]jsonpatch.Patch, len(o.PatchFilePaths))
+
+	for i, patchFilePath := range o.PatchFilePaths {
+		var bs []byte
+		bs, err = ioutil.ReadFile(patchFilePath.Path())
+		if err != nil {
+			log.Fatalf("error reading patch file: %s", err)
+		}
+
+		var patch jsonpatch.Patch
+		patch, err = jsonpatch.DecodePatch(bs)
+		if err != nil {
+			log.Fatalf("error decoding patch file: %s", err)
+		}
+
+		patches[i] = patch
+	}
+
+	doc, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("error reading from stdin: %s", err)
+	}
+
+	mdoc := doc
+	for _, patch := range patches {
+		mdoc, err = patch.Apply(mdoc)
+		if err != nil {
+			log.Fatalf("error applying patch: %s", err)
+		}
+	}
+
+	fmt.Printf("%s", mdoc)
+}

--- a/vendor/github.com/evanphx/json-patch/merge.go
+++ b/vendor/github.com/evanphx/json-patch/merge.go
@@ -1,0 +1,383 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+func merge(cur, patch *lazyNode, mergeMerge bool) *lazyNode {
+	curDoc, err := cur.intoDoc()
+
+	if err != nil {
+		pruneNulls(patch)
+		return patch
+	}
+
+	patchDoc, err := patch.intoDoc()
+
+	if err != nil {
+		return patch
+	}
+
+	mergeDocs(curDoc, patchDoc, mergeMerge)
+
+	return cur
+}
+
+func mergeDocs(doc, patch *partialDoc, mergeMerge bool) {
+	for k, v := range *patch {
+		if v == nil {
+			if mergeMerge {
+				(*doc)[k] = nil
+			} else {
+				delete(*doc, k)
+			}
+		} else {
+			cur, ok := (*doc)[k]
+
+			if !ok || cur == nil {
+				pruneNulls(v)
+				(*doc)[k] = v
+			} else {
+				(*doc)[k] = merge(cur, v, mergeMerge)
+			}
+		}
+	}
+}
+
+func pruneNulls(n *lazyNode) {
+	sub, err := n.intoDoc()
+
+	if err == nil {
+		pruneDocNulls(sub)
+	} else {
+		ary, err := n.intoAry()
+
+		if err == nil {
+			pruneAryNulls(ary)
+		}
+	}
+}
+
+func pruneDocNulls(doc *partialDoc) *partialDoc {
+	for k, v := range *doc {
+		if v == nil {
+			delete(*doc, k)
+		} else {
+			pruneNulls(v)
+		}
+	}
+
+	return doc
+}
+
+func pruneAryNulls(ary *partialArray) *partialArray {
+	newAry := []*lazyNode{}
+
+	for _, v := range *ary {
+		if v != nil {
+			pruneNulls(v)
+			newAry = append(newAry, v)
+		}
+	}
+
+	*ary = newAry
+
+	return ary
+}
+
+var errBadJSONDoc = fmt.Errorf("Invalid JSON Document")
+var errBadJSONPatch = fmt.Errorf("Invalid JSON Patch")
+var errBadMergeTypes = fmt.Errorf("Mismatched JSON Documents")
+
+// MergeMergePatches merges two merge patches together, such that
+// applying this resulting merged merge patch to a document yields the same
+// as merging each merge patch to the document in succession.
+func MergeMergePatches(patch1Data, patch2Data []byte) ([]byte, error) {
+	return doMergePatch(patch1Data, patch2Data, true)
+}
+
+// MergePatch merges the patchData into the docData.
+func MergePatch(docData, patchData []byte) ([]byte, error) {
+	return doMergePatch(docData, patchData, false)
+}
+
+func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
+	doc := &partialDoc{}
+
+	docErr := json.Unmarshal(docData, doc)
+
+	patch := &partialDoc{}
+
+	patchErr := json.Unmarshal(patchData, patch)
+
+	if _, ok := docErr.(*json.SyntaxError); ok {
+		return nil, errBadJSONDoc
+	}
+
+	if _, ok := patchErr.(*json.SyntaxError); ok {
+		return nil, errBadJSONPatch
+	}
+
+	if docErr == nil && *doc == nil {
+		return nil, errBadJSONDoc
+	}
+
+	if patchErr == nil && *patch == nil {
+		return nil, errBadJSONPatch
+	}
+
+	if docErr != nil || patchErr != nil {
+		// Not an error, just not a doc, so we turn straight into the patch
+		if patchErr == nil {
+			if mergeMerge {
+				doc = patch
+			} else {
+				doc = pruneDocNulls(patch)
+			}
+		} else {
+			patchAry := &partialArray{}
+			patchErr = json.Unmarshal(patchData, patchAry)
+
+			if patchErr != nil {
+				return nil, errBadJSONPatch
+			}
+
+			pruneAryNulls(patchAry)
+
+			out, patchErr := json.Marshal(patchAry)
+
+			if patchErr != nil {
+				return nil, errBadJSONPatch
+			}
+
+			return out, nil
+		}
+	} else {
+		mergeDocs(doc, patch, mergeMerge)
+	}
+
+	return json.Marshal(doc)
+}
+
+// resemblesJSONArray indicates whether the byte-slice "appears" to be
+// a JSON array or not.
+// False-positives are possible, as this function does not check the internal
+// structure of the array. It only checks that the outer syntax is present and
+// correct.
+func resemblesJSONArray(input []byte) bool {
+	input = bytes.TrimSpace(input)
+
+	hasPrefix := bytes.HasPrefix(input, []byte("["))
+	hasSuffix := bytes.HasSuffix(input, []byte("]"))
+
+	return hasPrefix && hasSuffix
+}
+
+// CreateMergePatch will return a merge patch document capable of converting
+// the original document(s) to the modified document(s).
+// The parameters can be bytes of either two JSON Documents, or two arrays of
+// JSON documents.
+// The merge patch returned follows the specification defined at http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
+func CreateMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalResemblesArray := resemblesJSONArray(originalJSON)
+	modifiedResemblesArray := resemblesJSONArray(modifiedJSON)
+
+	// Do both byte-slices seem like JSON arrays?
+	if originalResemblesArray && modifiedResemblesArray {
+		return createArrayMergePatch(originalJSON, modifiedJSON)
+	}
+
+	// Are both byte-slices are not arrays? Then they are likely JSON objects...
+	if !originalResemblesArray && !modifiedResemblesArray {
+		return createObjectMergePatch(originalJSON, modifiedJSON)
+	}
+
+	// None of the above? Then return an error because of mismatched types.
+	return nil, errBadMergeTypes
+}
+
+// createObjectMergePatch will return a merge-patch document capable of
+// converting the original document to the modified document.
+func createObjectMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDoc := map[string]interface{}{}
+	modifiedDoc := map[string]interface{}{}
+
+	err := json.Unmarshal(originalJSON, &originalDoc)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDoc)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	dest, err := getDiff(originalDoc, modifiedDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(dest)
+}
+
+// createArrayMergePatch will return an array of merge-patch documents capable
+// of converting the original document to the modified document for each
+// pair of JSON documents provided in the arrays.
+// Arrays of mismatched sizes will result in an error.
+func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDocs := []json.RawMessage{}
+	modifiedDocs := []json.RawMessage{}
+
+	err := json.Unmarshal(originalJSON, &originalDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	total := len(originalDocs)
+	if len(modifiedDocs) != total {
+		return nil, errBadJSONDoc
+	}
+
+	result := []json.RawMessage{}
+	for i := 0; i < len(originalDocs); i++ {
+		original := originalDocs[i]
+		modified := modifiedDocs[i]
+
+		patch, err := createObjectMergePatch(original, modified)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, json.RawMessage(patch))
+	}
+
+	return json.Marshal(result)
+}
+
+// Returns true if the array matches (must be json types).
+// As is idiomatic for go, an empty array is not the same as a nil array.
+func matchesArray(a, b []interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if (a == nil && b != nil) || (a != nil && b == nil) {
+		return false
+	}
+	for i := range a {
+		if !matchesValue(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Returns true if the values matches (must be json types)
+// The types of the values must match, otherwise it will always return false
+// If two map[string]interface{} are given, all elements must match.
+func matchesValue(av, bv interface{}) bool {
+	if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+		return false
+	}
+	switch at := av.(type) {
+	case string:
+		bt := bv.(string)
+		if bt == at {
+			return true
+		}
+	case float64:
+		bt := bv.(float64)
+		if bt == at {
+			return true
+		}
+	case bool:
+		bt := bv.(bool)
+		if bt == at {
+			return true
+		}
+	case nil:
+		// Both nil, fine.
+		return true
+	case map[string]interface{}:
+		bt := bv.(map[string]interface{})
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt := bv.([]interface{})
+		return matchesArray(at, bt)
+	}
+	return false
+}
+
+// getDiff returns the (recursive) difference between a and b as a map[string]interface{}.
+func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
+	into := map[string]interface{}{}
+	for key, bv := range b {
+		av, ok := a[key]
+		// value was added
+		if !ok {
+			into[key] = bv
+			continue
+		}
+		// If types have changed, replace completely
+		if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+			into[key] = bv
+			continue
+		}
+		// Types are the same, compare values
+		switch at := av.(type) {
+		case map[string]interface{}:
+			bt := bv.(map[string]interface{})
+			dst := make(map[string]interface{}, len(bt))
+			dst, err := getDiff(at, bt)
+			if err != nil {
+				return nil, err
+			}
+			if len(dst) > 0 {
+				into[key] = dst
+			}
+		case string, float64, bool:
+			if !matchesValue(av, bv) {
+				into[key] = bv
+			}
+		case []interface{}:
+			bt := bv.([]interface{})
+			if !matchesArray(at, bt) {
+				into[key] = bv
+			}
+		case nil:
+			switch bv.(type) {
+			case nil:
+				// Both nil, fine.
+			default:
+				into[key] = bv
+			}
+		default:
+			panic(fmt.Sprintf("Unknown type:%T in key %s", av, key))
+		}
+	}
+	// Now add all deleted values as nil
+	for key := range a {
+		_, found := b[key]
+		if !found {
+			into[key] = nil
+		}
+	}
+	return into, nil
+}

--- a/vendor/github.com/evanphx/json-patch/patch.go
+++ b/vendor/github.com/evanphx/json-patch/patch.go
@@ -1,0 +1,682 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	eRaw = iota
+	eDoc
+	eAry
+)
+
+var SupportNegativeIndices bool = true
+
+type lazyNode struct {
+	raw   *json.RawMessage
+	doc   partialDoc
+	ary   partialArray
+	which int
+}
+
+type operation map[string]*json.RawMessage
+
+// Patch is an ordered collection of operations.
+type Patch []operation
+
+type partialDoc map[string]*lazyNode
+type partialArray []*lazyNode
+
+type container interface {
+	get(key string) (*lazyNode, error)
+	set(key string, val *lazyNode) error
+	add(key string, val *lazyNode) error
+	remove(key string) error
+}
+
+func newLazyNode(raw *json.RawMessage) *lazyNode {
+	return &lazyNode{raw: raw, doc: nil, ary: nil, which: eRaw}
+}
+
+func (n *lazyNode) MarshalJSON() ([]byte, error) {
+	switch n.which {
+	case eRaw:
+		return json.Marshal(n.raw)
+	case eDoc:
+		return json.Marshal(n.doc)
+	case eAry:
+		return json.Marshal(n.ary)
+	default:
+		return nil, fmt.Errorf("Unknown type")
+	}
+}
+
+func (n *lazyNode) UnmarshalJSON(data []byte) error {
+	dest := make(json.RawMessage, len(data))
+	copy(dest, data)
+	n.raw = &dest
+	n.which = eRaw
+	return nil
+}
+
+func (n *lazyNode) intoDoc() (*partialDoc, error) {
+	if n.which == eDoc {
+		return &n.doc, nil
+	}
+
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial document")
+	}
+
+	err := json.Unmarshal(*n.raw, &n.doc)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n.which = eDoc
+	return &n.doc, nil
+}
+
+func (n *lazyNode) intoAry() (*partialArray, error) {
+	if n.which == eAry {
+		return &n.ary, nil
+	}
+
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial array")
+	}
+
+	err := json.Unmarshal(*n.raw, &n.ary)
+
+	if err != nil {
+		return nil, err
+	}
+
+	n.which = eAry
+	return &n.ary, nil
+}
+
+func (n *lazyNode) compact() []byte {
+	buf := &bytes.Buffer{}
+
+	if n.raw == nil {
+		return nil
+	}
+
+	err := json.Compact(buf, *n.raw)
+
+	if err != nil {
+		return *n.raw
+	}
+
+	return buf.Bytes()
+}
+
+func (n *lazyNode) tryDoc() bool {
+	if n.raw == nil {
+		return false
+	}
+
+	err := json.Unmarshal(*n.raw, &n.doc)
+
+	if err != nil {
+		return false
+	}
+
+	n.which = eDoc
+	return true
+}
+
+func (n *lazyNode) tryAry() bool {
+	if n.raw == nil {
+		return false
+	}
+
+	err := json.Unmarshal(*n.raw, &n.ary)
+
+	if err != nil {
+		return false
+	}
+
+	n.which = eAry
+	return true
+}
+
+func (n *lazyNode) equal(o *lazyNode) bool {
+	if n.which == eRaw {
+		if !n.tryDoc() && !n.tryAry() {
+			if o.which != eRaw {
+				return false
+			}
+
+			return bytes.Equal(n.compact(), o.compact())
+		}
+	}
+
+	if n.which == eDoc {
+		if o.which == eRaw {
+			if !o.tryDoc() {
+				return false
+			}
+		}
+
+		if o.which != eDoc {
+			return false
+		}
+
+		for k, v := range n.doc {
+			ov, ok := o.doc[k]
+
+			if !ok {
+				return false
+			}
+
+			if v == nil && ov == nil {
+				continue
+			}
+
+			if !v.equal(ov) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	if o.which != eAry && !o.tryAry() {
+		return false
+	}
+
+	if len(n.ary) != len(o.ary) {
+		return false
+	}
+
+	for idx, val := range n.ary {
+		if !val.equal(o.ary[idx]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (o operation) kind() string {
+	if obj, ok := o["op"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) path() string {
+	if obj, ok := o["path"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) from() string {
+	if obj, ok := o["from"]; ok && obj != nil {
+		var op string
+
+		err := json.Unmarshal(*obj, &op)
+
+		if err != nil {
+			return "unknown"
+		}
+
+		return op
+	}
+
+	return "unknown"
+}
+
+func (o operation) value() *lazyNode {
+	if obj, ok := o["value"]; ok {
+		return newLazyNode(obj)
+	}
+
+	return nil
+}
+
+func isArray(buf []byte) bool {
+Loop:
+	for _, c := range buf {
+		switch c {
+		case ' ':
+		case '\n':
+		case '\t':
+			continue
+		case '[':
+			return true
+		default:
+			break Loop
+		}
+	}
+
+	return false
+}
+
+func findObject(pd *container, path string) (container, string) {
+	doc := *pd
+
+	split := strings.Split(path, "/")
+
+	if len(split) < 2 {
+		return nil, ""
+	}
+
+	parts := split[1 : len(split)-1]
+
+	key := split[len(split)-1]
+
+	var err error
+
+	for _, part := range parts {
+
+		next, ok := doc.get(decodePatchKey(part))
+
+		if next == nil || ok != nil {
+			return nil, ""
+		}
+
+		if isArray(*next.raw) {
+			doc, err = next.intoAry()
+
+			if err != nil {
+				return nil, ""
+			}
+		} else {
+			doc, err = next.intoDoc()
+
+			if err != nil {
+				return nil, ""
+			}
+		}
+	}
+
+	return doc, decodePatchKey(key)
+}
+
+func (d *partialDoc) set(key string, val *lazyNode) error {
+	(*d)[key] = val
+	return nil
+}
+
+func (d *partialDoc) add(key string, val *lazyNode) error {
+	(*d)[key] = val
+	return nil
+}
+
+func (d *partialDoc) get(key string) (*lazyNode, error) {
+	return (*d)[key], nil
+}
+
+func (d *partialDoc) remove(key string) error {
+	_, ok := (*d)[key]
+	if !ok {
+		return fmt.Errorf("Unable to remove nonexistent key: %s", key)
+	}
+
+	delete(*d, key)
+	return nil
+}
+
+func (d *partialArray) set(key string, val *lazyNode) error {
+	if key == "-" {
+		*d = append(*d, val)
+		return nil
+	}
+
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	sz := len(*d)
+	if idx+1 > sz {
+		sz = idx + 1
+	}
+
+	ary := make([]*lazyNode, sz)
+
+	cur := *d
+
+	copy(ary, cur)
+
+	if idx >= len(ary) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	ary[idx] = val
+
+	*d = ary
+	return nil
+}
+
+func (d *partialArray) add(key string, val *lazyNode) error {
+	if key == "-" {
+		*d = append(*d, val)
+		return nil
+	}
+
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	ary := make([]*lazyNode, len(*d)+1)
+
+	cur := *d
+
+	if idx >= len(ary) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	if SupportNegativeIndices {
+		if idx < -len(ary) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+
+		if idx < 0 {
+			idx += len(ary)
+		}
+	}
+
+	copy(ary[0:idx], cur[0:idx])
+	ary[idx] = val
+	copy(ary[idx+1:], cur[idx:])
+
+	*d = ary
+	return nil
+}
+
+func (d *partialArray) get(key string) (*lazyNode, error) {
+	idx, err := strconv.Atoi(key)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if idx >= len(*d) {
+		return nil, fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	return (*d)[idx], nil
+}
+
+func (d *partialArray) remove(key string) error {
+	idx, err := strconv.Atoi(key)
+	if err != nil {
+		return err
+	}
+
+	cur := *d
+
+	if idx >= len(cur) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
+
+	if SupportNegativeIndices {
+		if idx < -len(cur) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+
+		if idx < 0 {
+			idx += len(cur)
+		}
+	}
+
+	ary := make([]*lazyNode, len(cur)-1)
+
+	copy(ary[0:idx], cur[0:idx])
+	copy(ary[idx:], cur[idx+1:])
+
+	*d = ary
+	return nil
+
+}
+
+func (p Patch) add(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: \"%s\"", path)
+	}
+
+	return con.add(key, op.value())
+}
+
+func (p Patch) remove(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: \"%s\"", path)
+	}
+
+	return con.remove(key)
+}
+
+func (p Patch) replace(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
+	}
+
+	_, ok := con.get(key)
+	if ok != nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing key: %s", path)
+	}
+
+	return con.set(key, op.value())
+}
+
+func (p Patch) move(doc *container, op operation) error {
+	from := op.from()
+
+	con, key := findObject(doc, from)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing from path: %s", from)
+	}
+
+	val, err := con.get(key)
+	if err != nil {
+		return err
+	}
+
+	err = con.remove(key)
+	if err != nil {
+		return err
+	}
+
+	path := op.path()
+
+	con, key = findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing destination path: %s", path)
+	}
+
+	return con.set(key, val)
+}
+
+func (p Patch) test(doc *container, op operation) error {
+	path := op.path()
+
+	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch test operation does not apply: is missing path: %s", path)
+	}
+
+	val, err := con.get(key)
+
+	if err != nil {
+		return err
+	}
+
+	if val == nil {
+		if op.value().raw == nil {
+			return nil
+		}
+		return fmt.Errorf("Testing value %s failed", path)
+	} else if op.value() == nil {
+		return fmt.Errorf("Testing value %s failed", path)
+	}
+
+	if val.equal(op.value()) {
+		return nil
+	}
+
+	return fmt.Errorf("Testing value %s failed", path)
+}
+
+func (p Patch) copy(doc *container, op operation) error {
+	from := op.from()
+
+	con, key := findObject(doc, from)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch copy operation does not apply: doc is missing from path: %s", from)
+	}
+
+	val, err := con.get(key)
+	if err != nil {
+		return err
+	}
+
+	path := op.path()
+
+	con, key = findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch copy operation does not apply: doc is missing destination path: %s", path)
+	}
+
+	return con.set(key, val)
+}
+
+// Equal indicates if 2 JSON documents have the same structural equality.
+func Equal(a, b []byte) bool {
+	ra := make(json.RawMessage, len(a))
+	copy(ra, a)
+	la := newLazyNode(&ra)
+
+	rb := make(json.RawMessage, len(b))
+	copy(rb, b)
+	lb := newLazyNode(&rb)
+
+	return la.equal(lb)
+}
+
+// DecodePatch decodes the passed JSON document as an RFC 6902 patch.
+func DecodePatch(buf []byte) (Patch, error) {
+	var p Patch
+
+	err := json.Unmarshal(buf, &p)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// Apply mutates a JSON document according to the patch, and returns the new
+// document.
+func (p Patch) Apply(doc []byte) ([]byte, error) {
+	return p.ApplyIndent(doc, "")
+}
+
+// ApplyIndent mutates a JSON document according to the patch, and returns the new
+// document indented.
+func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
+	var pd container
+	if doc[0] == '[' {
+		pd = &partialArray{}
+	} else {
+		pd = &partialDoc{}
+	}
+
+	err := json.Unmarshal(doc, pd)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = nil
+
+	for _, op := range p {
+		switch op.kind() {
+		case "add":
+			err = p.add(&pd, op)
+		case "remove":
+			err = p.remove(&pd, op)
+		case "replace":
+			err = p.replace(&pd, op)
+		case "move":
+			err = p.move(&pd, op)
+		case "test":
+			err = p.test(&pd, op)
+		case "copy":
+			err = p.copy(&pd, op)
+		default:
+			err = fmt.Errorf("Unexpected kind: %s", op.kind())
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if indent != "" {
+		return json.MarshalIndent(pd, "", indent)
+	}
+
+	return json.Marshal(pd)
+}
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+
+var (
+	rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+)
+
+func decodePatchKey(k string) string {
+	return rfc6901Decoder.Replace(k)
+}


### PR DESCRIPTION
Added some simple unit tests for reading and writing the alertmanager config in a fake cluster. Also added one integration test to show that Read + Write + Pager Duty functions work together.

```
[dakini@nibbana configure-alertmanager-operator (add_unit_tests *$%)]$ clear; /usr/bin/go test -timeout 30s github.com/openshift/configure-alertmanager-operator/pkg/controller/secret  -v
=== RUN   Test_getAlertManagerConfig
--- PASS: Test_getAlertManagerConfig (0.00s)
    secret_controller_test.go:119: Passed, using default config. getAlertManagerConfig() returned:
        global:
          resolve_timeout: 5m
        route:
          receiver: "null"
          group_by:
          - job
          routes:
          - receiver: "null"
            match:
              alertname: Watchdog
          group_wait: 30s
          group_interval: 5m
          repeat_interval: 12h
        receivers:
        - name: "null"
        templates: []

=== RUN   Test_updateAlertManagerConfig
--- PASS: Test_updateAlertManagerConfig (0.00s)
    secret_controller_test.go:146: Passed, modified 'group_wait' in default config. getAlertManagerConfig() returned:
        global:
          resolve_timeout: 5m
        route:
          receiver: "null"
          group_by:
          - job
          routes:
          - receiver: "null"
            match:
              alertname: Watchdog
          group_wait: 10s
          group_interval: 5m
          repeat_interval: 12h
        receivers:
        - name: "null"
        templates: []

=== RUN   Test_addPDSecretToAlertManagerConfig
--- PASS: Test_addPDSecretToAlertManagerConfig (0.00s)
    secret_controller_test.go:248: Passed, using Pager Duty config. getAlertManagerConfig() returned:
        global:
          resolve_timeout: 5m
          pagerduty_url: https://events.pagerduty.com/v2/enqueue
        route:
          receiver: "null"
          group_by:
          - job
          routes:
          - receiver: "null"
            match:
              alertname: Watchdog
          - receiver: pagerduty
            group_by:
            - alertname
            - severity
            match_re:
              namespace: ^openshift$|openshift-.*|default$|kube$|kube-.*|logging$
            continue: true
          group_wait: 30s
          group_interval: 5m
          repeat_interval: 12h
        receivers:
        - name: "null"
        - name: pagerduty
          pagerduty_configs:
          - send_resolved: true
            routing_key: asdf1234567890
            description: '{{ .CommonLabels.alertname }} {{ .CommonLabels.severity | toUpper
              }} ({{ len .Alerts }})'
            details:
              component: '{{ .CommonLabels.alertname }}'
              group: '{{ .CommonLabels.alertname }}'
              link: '{{ .CommonAnnotations.link }}?'
              num_firing: '{{ .Alerts.Firing | len }}'
              num_resolved: '{{ .Alerts.Resolved | len }}'
              resolved: '{{ template pagerduty.default.instances .Alerts.Resolved }}'
        templates: []

PASS
ok      github.com/openshift/configure-alertmanager-operator/pkg/controller/secret      0.010s
```