### PR TITLE
Build should push images to Quay

### DIFF
--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -10,4 +10,4 @@ fi
 
 # Build the image
 
-make IMAGE_REPOSITORY=$IMAGE_REPOSITORY build skopeo-push
+make IMAGE_REPOSITORY=$IMAGE_REPOSITORY build skopeo-push build-catalog-image

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -10,4 +10,4 @@ fi
 
 # Build the image
 
-make IMAGE_REPOSITORY=$IMAGE_REPOSITORY build
+make IMAGE_REPOSITORY=$IMAGE_REPOSITORY build skopeo-push


### PR DESCRIPTION
This PR resolves an issue where the build pipeline fails because images are not pushed to Quay.