### PR TITLE
Updated placeholder guage's label

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,5 +59,5 @@ func RegisterMetrics() error {
 // UpdatePlaceholderGauge ...
 func UpdatePlaceholderGauge() {
 
-	metricPlaceholder.With(prometheus.Labels{"name": "pagerduty-operator"}).Set(float64(1))
+	metricPlaceholder.With(prometheus.Labels{"name": "configure-alertmanager-operator"}).Set(float64(1))
 }


### PR DESCRIPTION
I know it will go away, but it wasn't consistent w/ other operator placeholder metrics.