### PR TITLE
Rename alerts and add to olm-artifacts-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ The Configure Alertmanager Operator exposes the following Prometheus metrics:
 
 ## Alerts
 The following alerts are added to Prometheus as part of configure-alertmanager-operator:
-* Mismatch between DMS secret and DMS Alertmanager config.
-* Mismatch between PD secret and PD Alertmanager config.
-* Alertmanager config secret does not exist.
+* Mismatch_between_DMS_secret_and_DMS_Alertmanager_config. Alerts if the Alertmanager config stays out-of-sync with Dead Man's Snitch secret for 5 minutes.
+* Mismatch_between_PD_secret_and_PD_Alertmanager_config. Alerts if the Alertmanager config stays out-of-sync with the Pager Duty secret for 5 minutes.
+* Alertmanager_config_secret_does_not_exist. Alerts if the `alertmanager-main` secret is missing from `openshift-monitoring` namespace for 5 minutes.

--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -51,3 +51,36 @@ objects:
         name: configure-alertmanager-operator
         source: configure-alertmanager-operator-registry
         sourceNamespace: openshift-operator-lifecycle-manager
+    - apiVersion: monitoring.coreos.com/v1
+    kind: PrometheusRule
+    metadata:
+      name: configure-alertmanager-operator
+      namespace: openshift-monitoring
+    spec:
+      groups:
+      - name: configure-alertmanager-operator
+        rules:
+        - alert: Mismatch_between_DMS_secret_and_DMS_Alertmanager_config
+          annotations:
+            message: "Mismatch between DMS secret and DMS AlertManager config"
+            link_url: "https://access.redhat.com/articles/4165971"
+          expr: dms_secret_exists + am_secret_contains_dms = 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: Mismatch_between_PD_secret_and_PD_Alertmanager_config
+          annotations:
+            message: "Mismatch between PD secret and PD AlertManager config"
+            link_url: "https://access.redhat.com/articles/4165971"
+          expr: pd_secret_exists + am_secret_contains_pd = 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: Alertmanager_config_secret_does_not_exist
+          annotations:
+            message: "Alertmanager config secret does not exist"
+            link_url: "https://access.redhat.com/articles/4165971"
+          expr: am_secret_exists = 0
+          for: 5m
+          labels:
+            severity: critical

--- a/manifests/05_prometheusrules.yaml
+++ b/manifests/05_prometheusrules.yaml
@@ -7,7 +7,7 @@ spec:
   groups:
   - name: configure-alertmanager-operator
     rules:
-    - alert: Mismatch between DMS secret and DMS Alertmanager config
+    - alert: Mismatch_between_DMS_secret_and_DMS_Alertmanager_config
       annotations:
         message: "Mismatch between DMS secret and DMS AlertManager config"
         link_url: "https://access.redhat.com/articles/4165971"
@@ -15,7 +15,7 @@ spec:
       for: 5m
       labels:
         severity: critical
-    - alert: Mismatch between PD secret and PD Alertmanager config
+    - alert: Mismatch_between_PD_secret_and_PD_Alertmanager_config
       annotations:
         message: "Mismatch between PD secret and PD AlertManager config"
         link_url: "https://access.redhat.com/articles/4165971"
@@ -23,7 +23,7 @@ spec:
       for: 5m
       labels:
         severity: critical
-    - alert: Alertmanager config secret does not exist
+    - alert: Alertmanager_config_secret_does_not_exist
       annotations:
         message: "Alertmanager config secret does not exist"
         link_url: "https://access.redhat.com/articles/4165971"


### PR DESCRIPTION
The alerts needed to be renamed git match this regex: [a-zA-Z_:][a-zA-Z0-9_:]*.
Also added alerts to olm-artifacts template. Will need to automate keeping those in sync (SREP-1382).