### PR TITLE
Fix PD regex and resolved template

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -228,7 +228,7 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 			"component":    `{{ .CommonLabels.alertname }}`,
 			"num_firing":   `{{ .Alerts.Firing | len }}`,
 			"num_resolved": `{{ .Alerts.Resolved | len }}`,
-			"resolved":     `{{ template pagerduty.default.instances .Alerts.Resolved }}`,
+			"resolved":     `{{ template "pagerduty.default.instances" .Alerts.Resolved }}`,
 		},
 	}
 

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -177,7 +177,7 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 			"component":    `{{ .CommonLabels.alertname }}`,
 			"num_firing":   `{{ .Alerts.Firing | len }}`,
 			"num_resolved": `{{ .Alerts.Resolved | len }}`,
-			"resolved":     `{{ template pagerduty.default.instances .Alerts.Resolved }}`,
+			"resolved":     `{{ template "pagerduty.default.instances" .Alerts.Resolved }}`,
 		},
 	}
 	pdroute := &alertmanager.Route{

--- a/pkg/types/alertmanagerconfig.go
+++ b/pkg/types/alertmanagerconfig.go
@@ -8,7 +8,7 @@ import (
 
 // PDRegex is the regular expression used in the Pager Duty receiver.
 // This is specific to our environment.
-const PDRegex string = "^kube-.*,^openshift-.*,^logging$,^default$,^openshift$,^ops-health-monitoring$,^ops-project-operation-check$,^management-infra$"
+const PDRegex string = "^kube-.*|^openshift-.*|^logging$|^default$|^openshift$|^ops-health-monitoring$|^ops-project-operation-check$|^management-infra$"
 
 // The following types are taken from the upstream Alertmanager types, and modified
 // to allow printing of Secrets so that we can generate valid configs from them.


### PR DESCRIPTION
Regex delimiter is pipe, not comma.
And the resolved template's first arg doesn't work unless it's in double quotes.  Might work with single, but based this on what was functioning in another cluster.