### PR TITLE
SREP-1352: Add Severity labels for alerts

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -221,6 +221,7 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 	pdconfig := &alertmanager.PagerdutyConfig{
 		NotifierConfig: alertmanager.NotifierConfig{VSendResolved: true},
 		RoutingKey:     pdsecret,
+		Severity:       `{{ if .CommonLabels.severity }}{{ .CommonLabels.severity | toLower }}{{ else }}critical{{ end }}`,
 		Description:    `{{ .CommonLabels.alertname }} {{ .CommonLabels.severity | toUpper }} ({{ len .Alerts }})`,
 		Details: map[string]string{
 			"link":         `{{ .CommonAnnotations.link }}?`,

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -170,6 +170,7 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 	pdconfig := &alertmanager.PagerdutyConfig{
 		NotifierConfig: alertmanager.NotifierConfig{VSendResolved: true},
 		RoutingKey:     pdsecret,
+		Severity:       `{{ if .CommonLabels.severity }}{{ .CommonLabels.severity | toLower }}{{ else }}critical{{ end }}`,
 		Description:    `{{ .CommonLabels.alertname }} {{ .CommonLabels.severity | toUpper }} ({{ len .Alerts }})`,
 		Details: map[string]string{
 			"link":         `{{ .CommonAnnotations.link }}?`,


### PR DESCRIPTION
Note that this won't do anything on its own inside PagerDuty until https://github.com/openshift/pagerduty-operator/pull/49 is also deployed (and backported to existing PagerDuty services). The reason is that by default, the PagerDuty services are created with an "IncidentUrgencyRule" that sets urgency to "High" for every alert, even warnings. These two PRs will work in concert to support warnings being treated as low urgency.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>