### PR TITLE
do not filter alerts based on namespaces regex

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -265,9 +265,10 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 			"alertname",
 			"severity",
 		},
-		MatchRE: map[string]string{
+		// Commenting this out until we get more labels from prometheus-k8s-alert
+		/*MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
-		},
+		},*/
 	}
 
 	// Insert the Route for the Pager Duty Receiver.

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -188,9 +188,10 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 			"alertname",
 			"severity",
 		},
-		MatchRE: map[string]string{
+		// Commenting this out until we get more labels from prometheus-k8s-alert
+		/*MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
-		},
+		},*/
 	}
 	pdreceiver := &alertmanager.Receiver{
 		Name:             "pagerduty",


### PR DESCRIPTION
This is commenting out the regex that is filtering alerts out, so that only matching namespaces go to Pagerduty.
The prometheusrules used in the monitoring-operator do not tag alerts in that way, in return no alerts coming from those rules currently go to PagerDuty.
In order to enable alerting, this is commented out, once alertrules in the monitoring operator have more labels, including `namespace` that we can match on, this can be reenabled.