### PR TITLE
Exclude KubeAPILatencyHigh alert

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -268,6 +268,7 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 		},
 		MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
+			"alertname": "^((?!KubeAPILatencyHigh).)*",
 		},
 	}
 

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -191,6 +191,7 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 		},
 		MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
+			"alertname": "^((?!KubeAPILatencyHigh).)*",
 		},
 	}
 	pdreceiver := &alertmanager.Receiver{


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1922

KubeAPILatencyHigh is setup in prometheusrules to trigger a critical alert at 10 minutes.

Almost every one of these alerts is automatically resolved within 10 minutes of triggering.  SRE has only fixed one and it was a side effect of other issues on a cluster: https://redhat.pagerduty.com/alerts/PK2NDLT

