### PR TITLE
Add permissive option to image registry initializer

### DIFF
--- a/build/Dockerfile.catalog_registry
+++ b/build/Dockerfile.catalog_registry
@@ -3,6 +3,6 @@ FROM quay.io/openshift/origin-operator-registry:latest
 ARG SRC_BUNDLES
 
 COPY ${SRC_BUNDLES} manifests
-RUN initializer
+RUN initializer --permissive
 
 CMD ["registry-server", "-t", "/tmp/terminate.log"]


### PR DESCRIPTION
The configure-alertmanager-operator is missing the --permissive flag from the catalog image builds.

https://jira.coreos.com/browse/SREP-2123
