### PR TITLE
Revert af011b3

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -268,7 +268,6 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 		},
 		MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
-			"alertname": "^((?!KubeAPILatencyHigh).)*",
 		},
 	}
 

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -191,7 +191,6 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 		},
 		MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
-			"alertname": "^((?!KubeAPILatencyHigh).)*",
 		},
 	}
 	pdreceiver := &alertmanager.Receiver{


### PR DESCRIPTION
Revert "Merge pull request #42 from liamwazherealso/modify-KubeAPILatency-alerts"

This reverts commit af011b389be791ec86c4b93970aa9df7da8c78a7, reversing
changes made to 5f1c7d8dcff14808a4d2e9dddaea23ce27ede7f7.

This change broke alert manager, as this is invalid RE syntax (go doesn't support negative lookaheads)