### PR TITLE
Suppress KubeAPILatencyHigh

### DIFF
--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -194,7 +194,7 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 		},
 		Routes: []*alertmanager.Route{
 			{
-				Receiver: "blackhole",
+				Receiver: "make-it-warning",
 				Match: map[string]string{
 					"alertname": "KubeAPILatencyHigh",
 				},
@@ -206,12 +206,14 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 		PagerdutyConfigs: []*alertmanager.PagerdutyConfig{pdconfig},
 	}
 
-	blackholereceiver := &alertmanager.Receiver{
-		Name: "blackhole",
+	pdconfig.Severity = "warning"
+	makeitwarningabsent := &alertmanager.Receiver{
+		Name:             "make-it-warning",
+		PagerdutyConfigs: []*alertmanager.PagerdutyConfig{pdconfig},
 	}
 
 	want.Receivers = append(want.Receivers, pdreceiver)
-	want.Receivers = append(want.Receivers, blackholereceiver)
+	want.Receivers = append(want.Receivers, makeitwarningabsent)
 	want.Route.Routes = append(want.Route.Routes, pdroute)
 
 	want.Global.PagerdutyURL = "https://events.pagerduty.com/v2/enqueue"

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -192,13 +192,28 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 		MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
 		},
+		Routes: []*alertmanager.Route{
+			{
+				Receiver: "blackhole",
+				Match: map[string]string{
+					"alertname": "KubeAPILatencyHigh",
+				},
+			},
+		},
 	}
 	pdreceiver := &alertmanager.Receiver{
 		Name:             "pagerduty",
 		PagerdutyConfigs: []*alertmanager.PagerdutyConfig{pdconfig},
 	}
+
+	blackholereceiver := &alertmanager.Receiver{
+		Name: "blackhole",
+	}
+
 	want.Receivers = append(want.Receivers, pdreceiver)
+	want.Receivers = append(want.Receivers, blackholereceiver)
 	want.Route.Routes = append(want.Route.Routes, pdroute)
+
 	want.Global.PagerdutyURL = "https://events.pagerduty.com/v2/enqueue"
 
 	// Try to get the same result as `want`,


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1922

KubeAPILatencyHigh is setup in prometheusrules to trigger a critical alert at 10 minutes.

Almost every one of these alerts is automatically resolved within 10 minutes of triggering.  SRE has only fixed one and it was a side effect of other issues on a cluster.