### PR TITLE
Remove pd config for make-it-warning receiver

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -268,8 +268,7 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 		log.Info("make-it-warning receiver is absent. Creating new receiver.")
 		pdconfig.Severity = "warning"
 		newreceiver := &alertmanager.Receiver{
-			Name:             "make-it-warning",
-			PagerdutyConfigs: []*alertmanager.PagerdutyConfig{pdconfig},
+			Name: "make-it-warning",
 		}
 		amconfig.Receivers = append(amconfig.Receivers, newreceiver)
 	}

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -208,8 +208,7 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 
 	pdconfig.Severity = "warning"
 	makeitwarningabsent := &alertmanager.Receiver{
-		Name:             "make-it-warning",
-		PagerdutyConfigs: []*alertmanager.PagerdutyConfig{pdconfig},
+		Name: "make-it-warning",
 	}
 
 	want.Receivers = append(want.Receivers, pdreceiver)


### PR DESCRIPTION
To successfully suppress KubeAPILatencyHigh alerts removing the pd config will prevent the receiver from firing. 
