### PR TITLE
Add ability to send specific alerts to a null receiver

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -23,6 +23,12 @@ import (
 
 var log = logf.Log.WithName("secret_controller")
 
+var (
+	alertsRouteWarning = []string{
+		"KubeAPILatencyHigh",
+	}
+)
+
 // Add creates a new Secret Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -274,6 +280,18 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 		amconfig.Receivers = append(amconfig.Receivers, newreceiver)
 	}
 
+	var routes []*alertmanager.Route
+
+	for _, alert := range alertsRouteWarning {
+		routes = append(routes,
+			&alertmanager.Route{
+				Receiver: "make-it-warning",
+				Match: map[string]string{
+					"alertname": alert,
+				},
+			})
+	}
+
 	// Create a route for the new Pager Duty receiver
 	pdroute := &alertmanager.Route{
 		Continue: true,
@@ -285,14 +303,7 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 		MatchRE: map[string]string{
 			"namespace": alertmanager.PDRegex,
 		},
-		Routes: []*alertmanager.Route{
-			{
-				Receiver: "make-it-warning",
-				Match: map[string]string{
-					"alertname": "KubeAPILatencyHigh",
-				},
-			},
-		},
+		Routes: routes,
 	}
 
 	// Insert the Route for the Pager Duty Receiver.

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -27,6 +27,10 @@ var (
 	alertsRouteWarning = []string{
 		"KubeAPILatencyHigh",
 	}
+
+	alertsRouteNull = []string{
+		"KubeQuotaExceeded",
+	}
 )
 
 // Add creates a new Secret Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -286,6 +290,16 @@ func addPDSecretToAlertManagerConfig(r *ReconcileSecret, request *reconcile.Requ
 		routes = append(routes,
 			&alertmanager.Route{
 				Receiver: "make-it-warning",
+				Match: map[string]string{
+					"alertname": alert,
+				},
+			})
+	}
+
+	for _, alert := range alertsRouteNull {
+		routes = append(routes,
+			&alertmanager.Route{
+				Receiver: "null",
 				Match: map[string]string{
 					"alertname": alert,
 				},

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -199,6 +199,12 @@ func Test_addPDSecretToAlertManagerConfig(t *testing.T) {
 					"alertname": "KubeAPILatencyHigh",
 				},
 			},
+			{
+				Receiver: "null",
+				Match: map[string]string{
+					"alertname": "KubeQuotaExceeded",
+				},
+			},
 		},
 	}
 	pdreceiver := &alertmanager.Receiver{


### PR DESCRIPTION
The "KubeQuotaExceeded" alert is not actionable in OSD, so this sends this specific alert to a null receiver.