### PR TITLE
move configure-alertmanager-operator pod to infra nodes

### DIFF
--- a/manifests/04_operator.yaml
+++ b/manifests/04_operator.yaml
@@ -14,6 +14,12 @@ spec:
         name: configure-alertmanager-operator
     spec:
       serviceAccountName: configure-alertmanager-operator
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
       containers:
         - name: configure-alertmanager-operator
           image: quay.io/app-sre/configure-alertmanager-operator:staging-latest


### PR DESCRIPTION
Implements: OSD-2394

testing done:  whether it deployed exactly onto infra nodes.

- Add toleration for NoSchedule taints
- Add nodeSelector for infra nodes