### PR TITLE
move configure-alertmanager-operator-registry pod(catalogsource) to infra nodes

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -35,6 +35,12 @@ objects:
         namespace: openshift-monitoring
       spec:
         image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
+        nodeSelector:
+          node-role.kubernetes.io/infra: ''
+        tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/infra
+            operator: Exists
         displayName: Configure Alertmanager Operator
         icon:
           base64data: ""


### PR DESCRIPTION
As discussed, we're now moving the CatalogSources as well to infra nodes.
I tested it in `beta` cluster for ensuring it's running on the `infra` labeled nodes.