### PR TITLE
Improve the operator image's score on quay.io

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,14 +1,22 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
-ENV OPERATOR_PATH=/go/src/github.com/openshift/configure-alertmanager-operator
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+
+# Allow specifying a GOPROXY cache during build to speed up dependency resolution
+ARG GOPROXY=https://proxy.golang.org
+
+ENV OPERATOR_PATH=/go/src/github.com/openshift/configure-alertmanager-operator \
+    GOPROXY=$GOPROXY
+
 COPY . ${OPERATOR_PATH}
 WORKDIR ${OPERATOR_PATH}
 RUN make gobuild
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+####
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
 ENV OPERATOR_PATH=/go/src/github.com/openshift/configure-alertmanager-operator \
     OPERATOR_BIN=configure-alertmanager-operator
 
-WORKDIR /root/
+# install operator binary
 COPY --from=builder ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
 LABEL io.openshift.managed.name="configure-alertmanager-operator" \
       io.openshift.managed.description="Operator to configure Alertmanager with PagerDuty and Dead Man's Snitch."


### PR DESCRIPTION
Current score for app-sre image (which was built 1 hour ago) is 16 High vulnerabilities.
https://quay.io/repository/app-sre/configure-alertmanager-operator?tab=tags

With this change the score changes to "Passed" (no vulnerabilities).
https://quay.io/repository/nmalik/configure-alertmanager-operator?tab=tags

To update the image I started with the Dockerfile from rbac-permissions-operator and incorporated what was needed and pushed to my personal quay.io account to see the score.  It still had a bad score.  I then updated the base image to ubi8.  I am not sure why rbac-permissions-operator is "Passed" with the ubi7 image.