### PR TITLE
Suppress SLAUptimeSRE alert

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -46,6 +46,8 @@ var (
 		{"alertname": "NodeFilesystemSpaceFillingUp", "severity": "warning"},
 		// https://issues.redhat.com/browse/OSD-2611
 		{"namespace": "openshift-customer-monitoring"},
+		// https://issues.redhat.com/browse/OSD-3220
+		{"alertname": "SLAUptimeSRE"},
 	}
 )
 


### PR DESCRIPTION
This is a paired commit to suppress SRE members being alerted for OSD-3220 (SLA tracking)
https://github.com/openshift/managed-cluster-config/pull/265