### PR TITLE
Bring build files up to standard

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,13 +1,26 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
-COPY . /go/src/github.com/openshift/configure-alertmanager-operator
-WORKDIR /go/src/github.com/openshift/configure-alertmanager-operator
-ENV GOFLAGS=""
+
+RUN mkdir -p /workdir
+WORKDIR /workdir
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
 RUN make gobuild
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-ENV OPERATOR_BIN=configure-alertmanager-operator
+####
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-WORKDIR /root/
-COPY --from=builder /go/src/github.com/openshift/configure-alertmanager-operator/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
+ENV USER_UID=1001 \
+    USER_NAME=configure-alertmanager-operator
+
+COPY --from=builder /workdir/build/_output/bin/* /usr/local/bin/
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}
+
 LABEL io.openshift.managed.name="configure-alertmanager-operator" \
       io.openshift.managed.description="Operator to configure Alertmanager with PagerDuty and Dead Man's Snitch."

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+
+# This is documented here:
+# https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines
+
+if ! whoami &>/dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-configure-alertmanager-operator}:x:$(id -u):$(id -g):${USER_NAME:-configure-alertmanager-operator} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec ${OPERATOR} $@

--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -x
+
+# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
+mkdir -p ${HOME}
+chown ${USER_UID}:0 ${HOME}
+chmod ug+rwx ${HOME}
+
+# runtime user will need to be able to self-insert in /etc/passwd
+chmod g+rw /etc/passwd
+
+# no need for this script to remain in the image after running
+rm $0

--- a/hack/codecov.sh
+++ b/hack/codecov.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
+COVER_PROFILE="coverage.out"
+JOB_TYPE=${JOB_TYPE:-"local"}
+
+make -C "${REPO_ROOT}" gotest TESTOPTS="-coverprofile=${COVER_PROFILE}.tmp -covermode=atomic -coverpkg=./..."
+
+# Remove generated files from coverage profile
+grep -v "zz_generated" "${COVER_PROFILE}.tmp" > "${COVER_PROFILE}"
+rm -f "${COVER_PROFILE}.tmp"
+
+# Configure the git refs and job link based on how the job was triggered via prow
+if [[ "${JOB_TYPE}" == "presubmit" ]]; then
+	echo "detected PR code coverage job for #${PULL_NUMBER}"
+	REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+	JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
+	echo "detected branch code coverage job for ${PULL_BASE_REF}"
+	REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+	JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "local" ]]; then
+	echo "coverage report available at ${COVER_PROFILE}"
+	exit 0
+else
+	echo "${JOB_TYPE} jobs not supported"
+	exit 1
+fi
+
+# Configure certain internal codecov variables with values from prow.
+export CI_BUILD_URL="${JOB_LINK}"
+export CI_BUILD_ID="${JOB_NAME}"
+export CI_JOB_ID="${BUILD_ID}"
+
+bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}


### PR DESCRIPTION
Copy Dockerfile, standard.mk, and hack/codecov.sh from managed-velero-operator

This updates us to UBI8, and brings in the framework for codecov

Follow up to #76