### PR TITLE
Mute all alerts to sre-p from openshift-operators namespace

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -115,6 +115,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemSpaceFillingUp", "severity": "warning"}},
 		// https://issues.redhat.com/browse/OSD-2611
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-customer-monitoring"}},
+                // https://issues.redhat.com/browse/OSD-3569
+                {Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-operators"}},
 		// https://issues.redhat.com/browse/OSD-3220
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "SLAUptimeSRE"}},
 		// https://issues.redhat.com/browse/OSD-3629

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -115,8 +115,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemSpaceFillingUp", "severity": "warning"}},
 		// https://issues.redhat.com/browse/OSD-2611
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-customer-monitoring"}},
-                // https://issues.redhat.com/browse/OSD-3569
-                {Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-operators"}},
+		// https://issues.redhat.com/browse/OSD-3569
+		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-operators"}},
 		// https://issues.redhat.com/browse/OSD-3220
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "SLAUptimeSRE"}},
 		// https://issues.redhat.com/browse/OSD-3629


### PR DESCRIPTION
Mute all alerts to sre-p from openshift-operators namespace

https://issues.redhat.com/browse/OSD-3569

https://redhat.pagerduty.com/alerts/P1Q5QBZ

This is a namespace where customers can deploy operators. SRE doesn't support those operators. Therefore, SRE shouldn't be alerted if there are any problems in that namespace.

Done:

    SREP is not alerted for any issues in openshift-operators namespace