### PR TITLE
Remove UsingDeprecatedAPI alerts

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -110,12 +110,6 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// This will be renamed in release 4.5
 		// https://issues.redhat.com/browse/OSD-4017
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubeQuotaFullyUsed"}},
-		// https://issues.redhat.com/browse/OSD-2382
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "UsingDeprecatedAPIAppsV1Beta1"}},
-		// https://issues.redhat.com/browse/OSD-2382
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "UsingDeprecatedAPIAppsV1Beta2"}},
-		// https://issues.redhat.com/browse/OSD-2382
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "UsingDeprecatedAPIExtensionsV1Beta1"}},
 		// https://issues.redhat.com/browse/OSD-2980
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CPUThrottlingHigh", "container": "registry-server"}},
 		// https://issues.redhat.com/browse/OSD-3008


### PR DESCRIPTION
These alerts don't exist in > 4.3.8