### PR TITLE
Provide console URL into PD alerts

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/configure-alertmanager-operator/pkg/controller"
 	operatormetrics "github.com/openshift/configure-alertmanager-operator/pkg/metrics"
 
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 
@@ -61,12 +60,6 @@ func main() {
 
 	printVersion()
 
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
-		os.Exit(1)
-	}
-
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -85,7 +78,6 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {

--- a/manifests/01_role.yaml
+++ b/manifests/01_role.yaml
@@ -58,6 +58,7 @@ rules:
   attributeRestrictions: null
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list
@@ -73,6 +74,7 @@ rules:
   attributeRestrictions: null
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/configure-alertmanager-operator/config"
 	"github.com/openshift/configure-alertmanager-operator/pkg/metrics"
 	alertmanager "github.com/openshift/configure-alertmanager-operator/pkg/types"
 
@@ -342,6 +343,10 @@ func (r *ReconcileSecret) getWebConsoleUrl() (string, error) {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	if request.Namespace != config.OperatorNamespace {
+		return reconcile.Result{}, nil
+	}
+
 	reqLogger := log.WithValues("Request.Name", request.Name)
 	reqLogger.Info("Reconciling Secret")
 

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -329,12 +329,12 @@ func (r *ReconcileSecret) getWebConsoleUrl() (string, error) {
 	consolePublicConfig := &corev1.ConfigMap{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: openShiftConfigManagedNamespaceName, Name: consolePublicConfigMap}, consolePublicConfig)
 	if err != nil {
-		return "", fmt.Errorf("unable to determine console location: %v", err)
+		return "", fmt.Errorf("unable to get console configmap: %v", err)
 	}
 
 	consoleUrl, exists := consolePublicConfig.Data["consoleURL"]
 	if !exists {
-		return "", fmt.Errorf("unable to determine console location from the cluster")
+		return "", fmt.Errorf("unable to determine console location from the configmap")
 	}
 	return consoleUrl, nil
 }
@@ -407,7 +407,7 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	// grab the console URL for PD alerts
 	consoleUrl, err := r.getWebConsoleUrl()
 	if err != nil {
-		return reconcile.Result{}, err
+		log.Error(err, "unable to determine console URL")
 	}
 
 	// create the desired alertmanager Config

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -19,6 +19,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	exampleConsoleUrl = "https://console-openshift-console.apps.cluster.abcd.t1.example.com"
+)
+
 // readAlertManagerConfig fetches the AlertManager configuration from its default location.
 // This is equivalent to `oc get secrets -n openshift-monitoring alertmanager-main`.
 // It specifically extracts the .data "alertmanager.yaml" field, and loads it into a resource
@@ -212,13 +216,13 @@ func Test_createPagerdutyRoute(t *testing.T) {
 }
 
 func Test_createPagerdutyReceivers_WithoutKey(t *testing.T) {
-	assertEquals(t, 0, len(createPagerdutyReceivers("")), "Number of Receivers")
+	assertEquals(t, 0, len(createPagerdutyReceivers("", "")), "Number of Receivers")
 }
 
 func Test_createPagerdutyReceivers_WithKey(t *testing.T) {
 	key := "abcdefg1234567890"
 
-	receivers := createPagerdutyReceivers(key)
+	receivers := createPagerdutyReceivers(key, exampleConsoleUrl)
 
 	verifyPagerdutyReceivers(t, key, receivers)
 }
@@ -246,7 +250,7 @@ func Test_createAlertManagerConfig_WithoutKey_WithoutURL(t *testing.T) {
 	pdKey := ""
 	wdURL := ""
 
-	config := createAlertManagerConfig(pdKey, wdURL)
+	config := createAlertManagerConfig(pdKey, wdURL, exampleConsoleUrl)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -267,7 +271,7 @@ func Test_createAlertManagerConfig_WithKey_WithoutURL(t *testing.T) {
 	pdKey := "poiuqwer78902345"
 	wdURL := ""
 
-	config := createAlertManagerConfig(pdKey, wdURL)
+	config := createAlertManagerConfig(pdKey, wdURL, exampleConsoleUrl)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -291,7 +295,7 @@ func Test_createAlertManagerConfig_WithKey_WithURL(t *testing.T) {
 	pdKey := "poiuqwer78902345"
 	wdURL := "http://theinterwebs"
 
-	config := createAlertManagerConfig(pdKey, wdURL)
+	config := createAlertManagerConfig(pdKey, wdURL, exampleConsoleUrl)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -318,7 +322,7 @@ func Test_createAlertManagerConfig_WithoutKey_WithURL(t *testing.T) {
 	pdKey := ""
 	wdURL := "http://theinterwebs"
 
-	config := createAlertManagerConfig(pdKey, wdURL)
+	config := createAlertManagerConfig(pdKey, wdURL, exampleConsoleUrl)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -335,6 +339,26 @@ func Test_createAlertManagerConfig_WithoutKey_WithURL(t *testing.T) {
 	verifyWatchdogReceiver(t, wdURL, config.Receivers)
 
 	verifyInhibitRules(t, config.InhibitRules)
+}
+
+// createConsolePublicConfigMap creates a fake namespace/configmap with console details
+func createConsolePublicConfigMap(reconciler *ReconcileSecret, t *testing.T) {
+	err := reconciler.client.Create(context.TODO(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: openShiftConfigManagedNamespaceName}})
+	if err != nil {
+		// exit the test if we can't create the namespace. Every test depends on this.
+		t.Errorf("Couldn't create the required namespace for the test. Encountered error: %s", err)
+		panic("Exiting due to fatal error")
+	}
+	newconfigmap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      consolePublicConfigMap,
+			Namespace: openShiftConfigManagedNamespaceName,
+		},
+		Data: map[string]string{
+			"consoleURL": exampleConsoleUrl,
+		},
+	}
+	reconciler.client.Create(context.TODO(), newconfigmap)
 }
 
 // createSecret creates a fake Secret to use in testing.
@@ -384,13 +408,14 @@ func Test_createPagerdutySecret_Create(t *testing.T) {
 	pdKey := "asdaidsgadfi9853"
 	wdURL := "http://theinterwebs/asdf"
 
-	configExpected := createAlertManagerConfig(pdKey, wdURL)
+	configExpected := createAlertManagerConfig(pdKey, wdURL, exampleConsoleUrl)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
 	// prepare environment
 	reconciler := createReconciler()
 	createNamespace(reconciler, t)
+	createConsolePublicConfigMap(reconciler, t)
 	createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
 	createSecret(reconciler, secretNameDMS, secretKeyDMS, wdURL)
 
@@ -409,13 +434,14 @@ func Test_createPagerdutySecret_Update(t *testing.T) {
 	pdKey := "asdaidsgadfi9853"
 	wdURL := "http://theinterwebs/asdf"
 
-	configExpected := createAlertManagerConfig(pdKey, wdURL)
+	configExpected := createAlertManagerConfig(pdKey, wdURL, exampleConsoleUrl)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
 	// prepare environment
 	reconciler := createReconciler()
 	createNamespace(reconciler, t)
+	createConsolePublicConfigMap(reconciler, t)
 	createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
 
 	// reconcile (one event should config everything)
@@ -516,13 +542,14 @@ func Test_ReconcileSecrets(t *testing.T) {
 	for _, tt := range tests {
 		reconciler := createReconciler()
 		createNamespace(reconciler, t)
+		createConsolePublicConfigMap(reconciler, t)
 
 		pdKey := ""
 		wdURL := ""
 
 		// Create the secrets for this specific test.
 		if tt.amExists {
-			writeAlertManagerConfig(reconciler, createAlertManagerConfig("", ""))
+			writeAlertManagerConfig(reconciler, createAlertManagerConfig("", "", ""))
 		}
 		if tt.dmsExists {
 			wdURL = "https://hjklasdf09876"
@@ -536,7 +563,7 @@ func Test_ReconcileSecrets(t *testing.T) {
 			createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
 		}
 
-		configExpected := createAlertManagerConfig(pdKey, wdURL)
+		configExpected := createAlertManagerConfig(pdKey, wdURL, exampleConsoleUrl)
 
 		verifyInhibitRules(t, configExpected.InhibitRules)
 


### PR DESCRIPTION
This grabs the console URL from the system configmap (same thing `oc` does here: https://github.com/openshift/oc/blob/f2a4a0375cc7b0eacb5467a0214303983e1151d6/pkg/cli/whoami/whoami.go#L115-L130) and then puts it into the alert configuration.

This will speed up alert response time, as an SRE can click immediately from the alert to access the cluster's console.