### PR TITLE
OSD-4616 KubePodNotReady or KubePodCrashLooping inhibit KubeDeploymentReplicasMismatch

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -343,6 +343,18 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, consoleUrl strin
 					"alertname": "KubeDeploymentReplicasMismatch",
 				},
 			},
+			{
+				Equal: []string{
+					"namespace",
+					"pod",
+				},
+				SourceMatch: map[string]string{
+					"alertname": "KubePodCrashLooping",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "KubeDeploymentReplicasMismatch",
+				},
+			},
 		},
 	}
 

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -331,6 +331,18 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, consoleUrl strin
 					"alertname": "KubeDaemonSetRolloutStuck",
 				},
 			},
+			{
+				Equal: []string{
+					"namespace",
+					"pod",
+				},
+				SourceMatch: map[string]string{
+					"alertname": "KubePodNotReady",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "KubeDeploymentReplicasMismatch",
+				},
+			},
 		},
 	}
 

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -268,6 +268,19 @@ func verifyInhibitRules(t *testing.T, inhibitRules []*alertmanager.InhibitRule) 
 			},
 			Expected: true,
 		},
+		{
+			SourceMatch: map[string]string{
+				"alertname": "KubePodCrashLooping",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "KubeDeploymentReplicasMismatch",
+			},
+			Equal: []string{
+				"namespace",
+				"pod",
+			},
+			Expected: true,
+		},
 	}
 
 	// keep track of which inhibition rules were affirmatively tested

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -255,6 +255,19 @@ func verifyInhibitRules(t *testing.T, inhibitRules []*alertmanager.InhibitRule) 
 			},
 			Expected: true,
 		},
+		{
+			SourceMatch: map[string]string{
+				"alertname": "KubePodNotReady",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "KubeDeploymentReplicasMismatch",
+			},
+			Equal: []string{
+				"namespace",
+				"pod",
+			},
+			Expected: true,
+		},
 	}
 
 	// keep track of which inhibition rules were affirmatively tested


### PR DESCRIPTION
when either KubePodNotReady or KubePodCrashLooping are firing, inhibit KubeDeploymentReplicasMismatch