### PR TITLE
Add missing apigroup to clusterrole

### DIFF
--- a/manifests/01_role.yaml
+++ b/manifests/01_role.yaml
@@ -54,7 +54,7 @@ metadata:
   name: configure-alertmanager-operator-view
 rules:
 - apiGroups:
-  - ""
+  - config.openshift.io
   attributeRestrictions: null
   resources:
   - clusterversions


### PR DESCRIPTION
Defines the missing api group of "config.openshift.io" needed for listing clusterversion resources.