### PR TITLE
pkg/controller/secret/secret_controller: mute es job failed alerts until SDE-895 is done

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -145,6 +145,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "CPUThrottlingHigh"}},
 		// https://issues.redhat.com/browse/OSD-4373
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "TargetDown"}},
+		// https://issues.redhat.com/browse/SDE-895 Mute until fixed
+		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-logging", "alertname": "KubeJobFailed"}},
 
 		// https://issues.redhat.com/browse/OSD-1922
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},


### PR DESCRIPTION
SRE-P is flooded with alerts caused by 

    1882846 – Redeployment of elasticsearch does not reuse or destroy existing pvc
        https://bugzilla.redhat.com/show_bug.cgi?id=1882846
    1881709 – elasticsearch-delete and elasticsearch-rollover pods hanging
        https://bugzilla.redhat.com/show_bug.cgi?id=1881709
    1882525 – elasticsearch-delete KeyError: 'is_write_index'
        https://bugzilla.redhat.com/show_bug.cgi?id=1882525
        *1866019 – elasticsearch-rollover and elasticsearch-delete pods in Error states
        https://bugzilla.redhat.com/show_bug.cgi?id=1866019
    1868675 – elasticsearch-rollover and elasticsearch-delete pods in Error states
        https://bugzilla.redhat.com/show_bug.cgi?id=1868675 (4.5.z version of 1866019)
    1885674 – Init container for fluentd failing due to certs
        https://bugzilla.redhat.com/show_bug.cgi?id=1885674
    1881957 – ElasticSearch operator upgrade created new PVCs
        https://bugzilla.redhat.com/show_bug.cgi?id=1881957
        Cloned from: 1868300 – ElasticSearch operator upgrade created new PVCs
        https://bugzilla.redhat.com/show_bug.cgi?id=1868300
    1885723 – Old kibana index causing crashloop
        https://bugzilla.redhat.com/show_bug.cgi?id=1885723

Start sending some of those to /dev/null