### PR TITLE
Fix skopeo push for container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,17 @@ include functions.mk
 
 CATALOG_REGISTRY_ORGANIZATION?=app-sre
 
+.PHONY: skopeo-push
+skopeo-push: build
+	skopeo copy \
+		--dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+		"docker-daemon:${OPERATOR_IMAGE_URI_LATEST}" \
+		"docker://${OPERATOR_IMAGE_URI_LATEST}"
+	skopeo copy \
+		--dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+		"docker-daemon:${OPERATOR_IMAGE_URI}" \
+		"docker://${OPERATOR_IMAGE_URI}"
+
 .PHONY: build-catalog-image
 build-catalog-image:
 	$(call create_push_catalog_image,staging,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/saas-osd-operators,$(OPERATOR_NAME)-services/$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -10,4 +10,4 @@ fi
 
 # Build the image
 
-make IMAGE_REPOSITORY=$IMAGE_REPOSITORY build push build-catalog-image
+make IMAGE_REPOSITORY=$IMAGE_REPOSITORY build skopeo-push build-catalog-image


### PR DESCRIPTION
Replaces the `skopeo-push` step required by app-sre CI. This was removed as a part of #101 / 69205363e29595168faa965cee0d226b45afd344