### PR TITLE
Swap the build-catalog-image variables back in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ skopeo-push: build
 
 .PHONY: build-catalog-image
 build-catalog-image:
-	$(call create_push_catalog_image,staging,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/saas-osd-operators,$(OPERATOR_NAME)-services/$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
-	$(call create_push_catalog_image,production,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,true,service/saas-osd-operators,$(OPERATOR_NAME)-services/$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
+	$(call create_push_catalog_image,staging,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
+	$(call create_push_catalog_image,production,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,true,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))

--- a/functions.mk
+++ b/functions.mk
@@ -18,7 +18,7 @@ define create_push_catalog_image
 	mkdir -p bundles-$(1)/$(OPERATOR_NAME) ;\
 	removed_versions="" ;\
 	if [[ "$$(echo $(4) | tr [:upper:] [:lower:])" == "true" ]]; then \
-		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/service/app-interface/-/raw/master/data/services/osd-operators/cicd/saas/saas-configure-alertmanager-operator.yaml' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
 		delete=false ;\
 		for bundle_path in $$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do \
 			if [[ "$${delete}" == false ]]; then \


### PR DESCRIPTION
This makes it so that these bits can be copied verbatim into other repos. I've tested this locally and it does the trick.