### PR TITLE
Remove nonexistent `build` dep from skopeo-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include functions.mk
 CATALOG_REGISTRY_ORGANIZATION?=app-sre
 
 .PHONY: skopeo-push
-skopeo-push: build
+skopeo-push:
 	skopeo copy \
 		--dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
 		"docker-daemon:${OPERATOR_IMAGE_URI_LATEST}" \


### PR DESCRIPTION
There's no `build` target. Strangely, `make` doesn't complain about this, and deployments are happening anyway. But clean it up anyway.