### PR TITLE
re-route the flipping alerts HAProxyReloadFail

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -147,6 +147,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "TargetDown"}},
 		// https://issues.redhat.com/browse/OSD-5544
 		{Receiver: receiverNull, MatchRE: map[string]string{"job_name": "^elasticsearch.*"}, Match: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-logging"}},
+		// Suppress the alerts and use HAProxyReloadFailSRE instead (openshift/managed-cluster-config#600)
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "HAProxyReloadFail", "severity": "critical"}},
 
 		// https://issues.redhat.com/browse/OSD-1922
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},


### PR DESCRIPTION
The alert HAProxyReloadFail is annoying, and we can do nothing except wait for it auto resolving.

We got more than 160 alerts for it for the past 2 weeks, and none of them is actionable.

Temporarily lower the severity till we got the fix landed.