### PR TITLE
Add to node alert inhibition rules

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -325,7 +325,18 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, consoleUrl strin
 			},
 			{
 				Equal: []string{
-					"namespace",
+					"node",
+					"instance",
+				},
+				SourceMatch: map[string]string{
+					"alertname": "KubeNodeUnreachable",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "KubeNodeNotReady",
+				},
+			},
+			{
+				Equal: []string{
 					"instance",
 				},
 				SourceMatch: map[string]string{
@@ -333,6 +344,39 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, consoleUrl strin
 				},
 				TargetMatchRE: map[string]string{
 					"alertname": "KubeDaemonSetRolloutStuck",
+				},
+			},
+			{
+				Equal: []string{
+					"instance",
+				},
+				SourceMatch: map[string]string{
+					"alertname": "KubeNodeNotReady",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "KubeDaemonSetMisScheduled",
+				},
+			},
+			{
+				Equal: []string{
+					"instance",
+				},
+				SourceMatch: map[string]string{
+					"alertname": "KubeNodeNotReady",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "SDNPodNotReady",
+				},
+			},
+			{
+				Equal: []string{
+					"instance",
+				},
+				SourceMatch: map[string]string{
+					"alertname": "KubeNodeNotReady",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "TargetDown",
 				},
 			},
 			{

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -248,13 +248,61 @@ func verifyInhibitRules(t *testing.T, inhibitRules []*alertmanager.InhibitRule) 
 		},
 		{
 			SourceMatch: map[string]string{
+				"alertname": "KubeNodeUnreachable",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "KubeNodeNotReady",
+			},
+			Equal: []string{
+				"node",
+				"instance",
+			},
+			Expected: true,
+		},
+		{
+			SourceMatch: map[string]string{
 				"alertname": "KubeNodeNotReady",
 			},
 			TargetMatchRE: map[string]string{
 				"alertname": "KubeDaemonSetRolloutStuck",
 			},
 			Equal: []string{
-				"namespace",
+				"instance",
+			},
+			Expected: true,
+		},
+		{
+			SourceMatch: map[string]string{
+				"alertname": "KubeNodeNotReady",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "KubeDaemonSetMisScheduled",
+			},
+			Equal: []string{
+				"instance",
+			},
+			Expected: true,
+		},
+		{
+			SourceMatch: map[string]string{
+				"alertname": "KubeNodeNotReady",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "SDNPodNotReady",
+			},
+			Equal: []string{
+				"instance",
+			},
+			Expected: true,
+		},
+		{
+			SourceMatch: map[string]string{
+				"alertname": "KubeNodeNotReady",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "TargetDown",
+			},
+			Equal: []string{
 				"instance",
 			},
 			Expected: true,


### PR DESCRIPTION
Add a few things to the node alert inhibition rules:
- If a node is `KubeNodeUnreachable`, then we can inhibit alerting on `KubeNodeNotReady`
- If `KubeNodeNotReady` is firing, then we can inhibit the following alerts:
  - `KubeDaemonSetMisScheduled`
  - `SDNPodNotReady`
  - `TargetDown`
