### PR TITLE
Further node replace inhibitions

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -341,6 +341,15 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, consoleUrl strin
 				},
 			},
 			{
+				// node being Unreachable may also trigger certain pods being unavailable
+				SourceMatch: map[string]string{
+					"alertname": "KubeNodeUnreachable",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "SDNPodNotReady|TargetDown",
+				},
+			},
+			{
 				// If a node is NotReady, then we also know that there will be pods that aren't running
 				Equal: []string{
 					"instance",
@@ -349,7 +358,7 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, consoleUrl strin
 					"alertname": "KubeNodeNotReady",
 				},
 				TargetMatchRE: map[string]string{
-					"alertname": "KubeDaemonSetRolloutStuck|KubeDaemonSetMisScheduled|SDNPodNotReady|TargetDown",
+					"alertname": "KubeDaemonSetRolloutStuck|KubeDaemonSetMisScheduled|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubePodNotReady",
 				},
 			},
 			{

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -260,6 +260,15 @@ func verifyInhibitRules(t *testing.T, inhibitRules []*alertmanager.InhibitRule) 
 			Expected: true,
 		},
 		{
+			SourceMatch: map[string]string{
+				"alertname": "KubeNodeUnreachable",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "SDNPodNotReady|TargetDown",
+			},
+			Expected: true,
+		},
+		{
 			Equal: []string{
 				"instance",
 			},
@@ -267,7 +276,7 @@ func verifyInhibitRules(t *testing.T, inhibitRules []*alertmanager.InhibitRule) 
 				"alertname": "KubeNodeNotReady",
 			},
 			TargetMatchRE: map[string]string{
-				"alertname": "KubeDaemonSetRolloutStuck|KubeDaemonSetMisScheduled|SDNPodNotReady|TargetDown",
+				"alertname": "KubeDaemonSetRolloutStuck|KubeDaemonSetMisScheduled|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubePodNotReady",
 			},
 			Expected: true,
 		},


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSD-5688 (Adjust alerts triggered when Machine health check replaces a node)
This is building on https://github.com/openshift/configure-alertmanager-operator/pull/126

Changes:
- From https://github.com/openshift/configure-alertmanager-operator/pull/126 i'm changing `TargetDown` and `SDNPodNotReady` to be inhibited if `KubeNodeUnreachable`  instead of `KubeNodeNotReady` because both those fire after 10m and `KubeNodeNotReady` is 15m so there is a 5 min gap where those alerts reach PD
- From https://github.com/openshift/configure-alertmanager-operator/pull/126 Removing `instance` match label on `TargetDown` as `TargetDown` doesn't have `instance`
-  Then just inhibiting `KubeDeploymentReplicasMismatch`, `KubeStatefulSetReplicasMismatch`, `KubePodNotReady` behind  `KubeNodeNotReady`