### PR TITLE
Add label to Pagerduty route

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -152,16 +152,17 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},
 
 		// https://issues.redhat.com/browse/OSD-3086
-		{Receiver: receiverPagerduty, MatchRE: map[string]string{"exported_namespace": alertmanager.PDRegex}},
+		// https://issues.redhat.com/browse/OSD-5872
+		{Receiver: receiverPagerduty, MatchRE: map[string]string{"exported_namespace": alertmanager.PDRegex}, Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
 		// general: route anything in core namespaces to PD
-		{Receiver: receiverPagerduty, MatchRE: map[string]string{"namespace": alertmanager.PDRegex}, Match: map[string]string{"exported_namespace": ""}},
+		{Receiver: receiverPagerduty, MatchRE: map[string]string{"namespace": alertmanager.PDRegex}, Match: map[string]string{"exported_namespace": "", "prometheus": "openshift-monitoring/k8s"}},
 		// fluentd: route any fluentd alert to PD
 		// https://issues.redhat.com/browse/OSD-3326
-		{Receiver: receiverPagerduty, Match: map[string]string{"job": "fluentd"}},
-		{Receiver: receiverPagerduty, Match: map[string]string{"alertname": "FluentdNodeDown"}},
+		{Receiver: receiverPagerduty, Match: map[string]string{"job": "fluentd", "prometheus": "openshift-monitoring/k8s"}},
+		{Receiver: receiverPagerduty, Match: map[string]string{"alertname": "FluentdNodeDown", "prometheus": "openshift-monitoring/k8s"}},
 		// elasticsearch: route any ES alert to PD
 		// https://issues.redhat.com/browse/OSD-3326
-		{Receiver: receiverPagerduty, Match: map[string]string{"cluster": "elasticsearch"}},
+		{Receiver: receiverPagerduty, Match: map[string]string{"cluster": "elasticsearch", "prometheus": "openshift-monitoring/k8s"}},
 	}
 
 	return &alertmanager.Route{


### PR DESCRIPTION
Per [OSD-5872](https://issues.redhat.com/browse/OSD-5872) this adds the label "prometheus" with the value of "openshfit-monitoring/k8s" to the PagerDuty route.