### PR TITLE
OSD-6363: Silence OAuthServerConfigObservation_Error

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -147,6 +147,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusRuleFailures"}},
 		// https://issues.redhat.com/browse/OSD-6215
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication", "reason": "IdentityProviderConfig_Error"}},
+		// https://issues.redhat.com/browse/OSD-6363
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication", "reason": "OAuthServerConfigObservation_Error"}},
 
 		// https://issues.redhat.com/browse/OSD-6327
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CannotRetrieveUpdates"}},


### PR DESCRIPTION
* OAuthServerConfigObservation_Error indicates a misconfigured IDP and shouldn't alert SRE
* It's not actionable by SRE, only the enduser can fix the IDP configuration in OCM

jira: [OSD-6363](https://issues.redhat.com/browse/OSD-6363)