### PR TITLE
Disable CPUThrottlingHigh alert - OSD-6351

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -112,7 +112,7 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-4017
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubeQuotaFullyUsed"}},
 		// TODO: Remove CPUThrottlingHigh entry after all OSD clusters upgrade to 4.6 and above version
-		// https://issues.redhat.com/browse/OSD-6351
+		// https://issues.redhat.com/browse/OSD-6351 based on https://bugzilla.redhat.com/show_bug.cgi?id=1843346
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CPUThrottlingHigh"}},
 		// https://issues.redhat.com/browse/OSD-3010
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemSpaceFillingUp", "severity": "warning"}},

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -111,10 +111,9 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// This will be renamed in release 4.5
 		// https://issues.redhat.com/browse/OSD-4017
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubeQuotaFullyUsed"}},
-		// https://issues.redhat.com/browse/OSD-2980
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "CPUThrottlingHigh", "container": "registry-server"}},
-		// https://issues.redhat.com/browse/OSD-3008
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "CPUThrottlingHigh", "container": "configmap-registry-server"}},
+		// TODO: Remove CPUThrottlingHigh entry after all OSD clusters upgrade to 4.6 and above version
+		// https://issues.redhat.com/browse/OSD-6351
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "CPUThrottlingHigh"}},
 		// https://issues.redhat.com/browse/OSD-3010
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemSpaceFillingUp", "severity": "warning"}},
 		// https://issues.redhat.com/browse/OSD-2611
@@ -133,8 +132,6 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "PodDisruptionBudgetLimit"}},
 		// https://issues.redhat.com/browse/OSD-3973
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "PodDisruptionBudgetAtLimit"}},
-		// https://issues.redhat.com/browse/OSD-4265, https://issues.redhat.com/browse/INTLY-8790
-		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "CPUThrottlingHigh"}},
 		// https://issues.redhat.com/browse/OSD-4373
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "TargetDown"}},
 		// https://issues.redhat.com/browse/OSD-5544


### PR DESCRIPTION
Based on [OSD-6351](https://issues.redhat.com/browse/OSD-6351), bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1843346 has disabled the CPUThrottlingHigh alert from 4.6 GA. However, we still have some clusters with OCP 4.5 where some of the clusters alert with CPUThrottlingHigh. 

This PR removes all previous selective configurations regarding silencing of CPUThrottlingHigh alert for a particular container or namespace and enables full silence for the alert. Once this is done, the other Jira i.e [OSD-2980](https://issues.redhat.com/browse/OSD-2980), [OSD-3008](https://issues.redhat.com/browse/OSD-3008) and [OSD-4265](https://issues.redhat.com/browse/OSD-4265) will be updated that their entry is removed by this PR.

cc: @cblecker, @dofinn 