### PR TITLE
Send PrometheusNotIngestingSamples for openshift-user-workload-monitoring to null receiver

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -148,6 +148,9 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-6327
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CannotRetrieveUpdates"}},
 
+		//https://issues.redhat.com/browse/OSD-6559
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusNotIngestingSamples", "namespace": "openshift-user-workload-monitoring"}},
+
 		// https://issues.redhat.com/browse/OSD-1922
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},
 


### PR DESCRIPTION
In 4.6, this alert fires by default as UWM has no scrape targets. Fixed in 4.7 but monitoring team recommended silencing the alerts.
https://issues.redhat.com/browse/OSD-6559