### PR TITLE
OSD-6505 Ignore alerts in openshift-operators

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -120,6 +120,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-customer-monitoring"}},
 		// https://issues.redhat.com/browse/OSD-3569
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-operators"}},
+		// https://issues.redhat.com/browse/OSD-6505
+		{Receiver: receiverNull, Match: map[string]string{"exported_namespace": "openshift-operators"}},
 		// https://issues.redhat.com/browse/OSD-3629
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CustomResourceDetected"}},
 		// https://issues.redhat.com/browse/OSD-3629


### PR DESCRIPTION
This PR routes all alerts with an `exported_namespace` of `openshift-operators` to null.

SRE do not manage any deployments within this namespace, so do not need to be alerted on it.

Similar work in [OSD-3569](https://issues.redhat.com/browse/OSD-3569) has already been performed in `configure-alertmanager-operator` for this namespace, but did not examine the `exported_namespace` metadata.

