### PR TITLE
OSD-6646: Ship monitoring CRB with OLM

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -63,3 +63,15 @@ objects:
         name: configure-alertmanager-operator
         source: configure-alertmanager-operator-registry
         sourceNamespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: configure-alertmanager-operator-prom
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-monitoring-view
+      subjects:
+      - kind: ServiceAccount
+        name: configure-alertmanager-operator
+        namespace: openshift-monitoring

--- a/manifests/03_role_binding.yaml
+++ b/manifests/03_role_binding.yaml
@@ -38,17 +38,3 @@ subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator
   namespace: openshift-monitoring
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: configure-alertmanager-operator.prom
-  namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-- kind: ServiceAccount
-  name: configure-alertmanager-operator
-  namespace: openshift-monitoring


### PR DESCRIPTION
Since #147, c-am-o needs to bind to the cluster-monitoring-view ClusterRole in order to be able to talk to prometheus. However, due to OLM limitations, we can't ship ClusterRoleBindings within the CSV or bundle. So instead ship it along with the OLMisms.

[OSD-6646](https://issues.redhat.com/browse/OSD-6646)