### PR TITLE
Ensure we have a DEPLOYED_HASH

### DIFF
--- a/functions.mk
+++ b/functions.mk
@@ -18,7 +18,12 @@ define create_push_catalog_image
 	mkdir -p bundles-$(1)/$(OPERATOR_NAME) ;\
 	removed_versions="" ;\
 	if [[ "$$(echo $(4) | tr [:upper:] [:lower:])" == "true" ]]; then \
-		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+		deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+		echo "Current deployed production HASH: $$deployed_hash" ;\
+		if [[ ! "$${deployed_hash}" =~ [0-9a-f]{40}  ]]; then \
+		    echo "Error discovering current production deployed HASH" ;\
+		    exit 1 ;\
+		fi ;\
 		delete=false ;\
 		for bundle_path in $$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do \
 			if [[ "$${delete}" == false ]]; then \


### PR DESCRIPTION
This one was hard to figure out. The SAAS path is correct but there was a missing `$` in `functions.mk` that too a long time to find. 

APPSRE SAAS files have different schemas depending on if its a Hive operator or not. We are silently failing on attempting to YQ an image from a file that doesn't exist, returning an empty hash.

This causes production catalog builds to look like staging bundles in respect to every version being added to the catalog.

For prod deploys don't deploy every version, this means on prod deploy there is a large jump from version to version causing CSV issues.

Debugged by modifying the `Makefile` and `functions.mk` 
```
diff --git a/Makefile b/Makefile
index 70a26eb..ba1acee 100644
--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ skopeo-push:
 
 .PHONY: build-catalog-image
 build-catalog-image:
-       $(call create_push_catalog_image,staging,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
+       #$(call create_push_catalog_image,staging,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,false,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
        $(call create_push_catalog_image,production,service/saas-configure-alertmanager-operator-bundle,$$APP_SRE_BOT_PUSH_TOKEN,true,service/app-interface,data/services/osd-operators/cicd/saas/saas-$(OPERATOR_NAME).yaml,build/generate-operator-bundle.py,$(CATALOG_REGISTRY_ORGANIZATION))
diff --git a/functions.mk b/functions.mk
index 40ead75..064ebcf 100644
--- a/functions.mk
+++ b/functions.mk
@@ -18,7 +18,13 @@ define create_push_catalog_image
        mkdir -p bundles-$(1)/$(OPERATOR_NAME) ;\
        removed_versions="" ;\
        if [[ "$$(echo $(4) | tr [:upper:] [:lower:])" == "true" ]]; then \
-               deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+               deployed_hash=$$(curl -s 'https://gitlab.cee.redhat.com/$(5)/raw/master/$(6)' | $(CONTAINER_ENGINE) run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.$$ref==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ;\
+               echo "Current deployed production HASH: $$deployed_hash" ;\
+               if [[ ! "$${deployed_hash}" =~ [0-9a-f]{40}  ]]; then \
+                   echo "Error discovering current production deployed HASH" ;\
+                   exit 1 ;\
+               fi ;\
+               exit 1 ;\
                delete=false ;\
                for bundle_path in $$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do \
                        if [[ "$${delete}" == false ]]; then \
@@ -33,6 +39,7 @@ define create_push_catalog_image
                        fi ;\
                done ;\
        fi ;\
+       exit 1 ;\
        previous_version=$$(find bundles-$(1) -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1| cut -d / -f 3-) ;\
        if [[ -z $$previous_version ]]; then \
                previous_version=__undefined__ ;\
(END)
```
Example failure

```
make build-catalog-image                                                                                
#       set -e ; git clone --branch staging "https://app:$APP_SRE_BOT_PUSH_TOKEN@gitlab.cee.redhat.com/service/saas-configure-alertmanager-operator-bundle.git" bundles-staging ; mkdir -p bundles-staging/configure-alertmanager-operator ; removed_versions=
"" ; if [[ "$(echo false | tr [:upper:] [:lower:])" == "true" ]]; then deployed_hash=$(curl -s 'https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-configure-alertmanager-operator.yaml' | /usr/bin/pod
man run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.ef==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ; echo "Current deployed production HASH: $deployed_hash" ; if [[ ! "${deployed_hash}" =~ [
0-9a-f]{40}  ]]; then echo "Error discovering current production deployed HASH" ; exit 1 ; fi ; exit 1 ; delete=false ; for bundle_path in $(find bundles-staging -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do if [[ "${delete}" == false ]];
 then bundle=$(echo $bundle_path | cut -d / -f 3-) ; version_hash=$(echo $bundle | cut -d - -f 2) ; if [[ 0.1.299-d986263 == "${version_hash}"* ]]; then delete=true ; fi ; else \rm -rf "${bundle_path}" ; removed_versions="$bundle $removed_versions" ; fi ; done ; fi ; exit 1 ; previous_version=$(find bundles-staging -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1| cut -d / -f 3-) ; if [[ -z $previous_version ]]; then previous_version=__undefined__ ; else previous_version="configure-a
lertmanager-operator.v${previous_version}" ; fi ; python build/generate-operator-bundle.py bundles-staging/configure-alertmanager-operator configure-alertmanager-operator openshift-monitoring 0.1.299-d986263 quay.io/jamesh/configure-alertmanager-operator:v0.1.299-d986263 staging true $previous_version ; new_version=$(find bundles-staging -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1 | cut -d / -f 3-) ; if [[ configure-alertmanager-operator.v${new_version} == $previous_version ]]; 
then echo "Already built this, so no need to continue" ; exit 0 ; fi ; sed -e "s/!CHANNEL!/staging/g" -e "s/!OPERATOR_NAME!/configure-alertmanager-operator/g" -e "s/!VERSION!/${new_version}/g" build/templates/package.yaml.tmpl > bundles-staging/configure
-alertmanager-operator/configure-alertmanager-operator.package.yaml ; cd bundles-staging ; git add . ; git commit -m "add version 299-d986263" -m "replaces: $previous_version" -m "removed versions: $removed_versions" ; git push origin staging ; cd .. ; /
usr/bin/podman build -f build/Dockerfile.catalog_registry --build-arg=SRC_BUNDLES=$(find bundles-staging -mindepth 1 -maxdepth 1 -type d | grep -v .git) -t quay.io/app-sre/configure-alertmanager-operator-registry:staging-latest . ; skopeo copy --dest-cre
ds $QUAY_USER:$QUAY_TOKEN "docker-daemon:quay.io/app-sre/configure-alertmanager-operator-registry:staging-latest" "docker://quay.io/app-sre/configure-alertmanager-operator-registry:staging-latest" ; skopeo copy --dest-creds $QUAY_USER:$QUAY_TOKEN "docker
-daemon:quay.io/app-sre/configure-alertmanager-operator-registry:staging-latest" "docker://quay.io/app-sre/configure-alertmanager-operator-registry:staging-d986263"                                                                                          
set -e ; git clone --branch production "https://app:$APP_SRE_BOT_PUSH_TOKEN@gitlab.cee.redhat.com/service/saas-configure-alertmanager-operator-bundle.git" bundles-production ; mkdir -p bundles-production/configure-alertmanager-operator ; removed_versions
="" ; if [[ "$(echo true | tr [:upper:] [:lower:])" == "true" ]]; then deployed_hash=$(curl -s 'https://gitlab.cee.redhat.com/service/app-interface/raw/master/data/services/osd-operators/cicd/saas/saas-configure-alertmanager-operator.yaml' | /usr/bin/pod
man run --rm -i quay.io/app-sre/yq:3.4.1 yq r - 'resourceTemplates[*].targets(namespace.ef==/services/osd-operators/namespaces/hivep01ue1/cluster-scope.yml).ref') ; echo "Current deployed production HASH: $deployed_hash" ; if [[ ! "${deployed_hash}" =~ [
0-9a-f]{40}  ]]; then echo "Error discovering current production deployed HASH" ; exit 1 ; fi ; exit 1 ; delete=false ; for bundle_path in $(find bundles-production -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V); do if [[ "${delete}" == false 
]]; then bundle=$(echo $bundle_path | cut -d / -f 3-) ; version_hash=$(echo $bundle | cut -d - -f 2) ; if [[ 0.1.299-d986263 == "${version_hash}"* ]]; then delete=true ; fi ; else \rm -rf "${bundle_path}" ; removed_versions="$bundle $removed_versions" ; 
fi ; done ; fi ; exit 1 ; previous_version=$(find bundles-production -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1| cut -d / -f 3-) ; if [[ -z $previous_version ]]; then previous_version=__undefined__ ; else previous_version="confi
gure-alertmanager-operator.v${previous_version}" ; fi ; python build/generate-operator-bundle.py bundles-production/configure-alertmanager-operator configure-alertmanager-operator openshift-monitoring 0.1.299-d986263 quay.io/jamesh/configure-alertmanager
-operator:v0.1.299-d986263 production true $previous_version ; new_version=$(find bundles-production -mindepth 2 -maxdepth 2 -type d | grep -v .git | sort -V | tail -n 1 | cut -d / -f 3-) ; if [[ configure-alertmanager-operator.v${new_version} == $previo
us_version ]]; then echo "Already built this, so no need to continue" ; exit 0 ; fi ; sed -e "s/!CHANNEL!/production/g" -e "s/!OPERATOR_NAME!/configure-alertmanager-operator/g" -e "s/!VERSION!/${new_version}/g" build/templates/package.yaml.tmpl > bundles
-production/configure-alertmanager-operator/configure-alertmanager-operator.package.yaml ; cd bundles-production ; git add . ; git commit -m "add version 299-d986263" -m "replaces: $previous_version" -m "removed versions: $removed_versions" ; git push or
igin production ; cd .. ; /usr/bin/podman build -f build/Dockerfile.catalog_registry --build-arg=SRC_BUNDLES=$(find bundles-production -mindepth 1 -maxdepth 1 -type d | grep -v .git) -t quay.io/app-sre/configure-alertmanager-operator-registry:production-
latest . ; skopeo copy --dest-creds $QUAY_USER:$QUAY_TOKEN "docker-daemon:quay.io/app-sre/configure-alertmanager-operator-registry:production-latest" "docker://quay.io/app-sre/configure-alertmanager-operator-registry:production-latest" ; skopeo copy --de
st-creds $QUAY_USER:$QUAY_TOKEN "docker-daemon:quay.io/app-sre/configure-alertmanager-operator-registry:production-latest" "docker://quay.io/app-sre/configure-alertmanager-operator-registry:production-d986263"
Cloning into 'bundles-production'...                
warning: redirecting to https://gitlab.cee.redhat.com/service/saas-configure-alertmanager-operator-bundle.git/                                                                                                                                                
remote: Enumerating objects: 206, done.                                                                                                                                                                                                                       
remote: Counting objects: 100% (206/206), done.
remote: Compressing objects: 100% (93/93), done.                                                                                                                                                                                                              
remote: Total 1314 (delta 143), reused 163 (delta 113), pack-reused 1108                                                                                                                                                                                      
Receiving objects: 100% (1314/1314), 114.38 KiB | 182.00 KiB/s, done.
Resolving deltas: 100% (1025/1025), done.
Current deployed production HASH: 
Error discovering current production deployed HASH
make: *** [Makefile:27: build-catalog-image] Error 1
```

Example working HASH - It exits one because I added that to stop the script (See debug above)

```
Cloning into 'bundles-production'...                                                                                                                                                                                                                          
warning: redirecting to https://gitlab.cee.redhat.com/service/saas-configure-alertmanager-operator-bundle.git/                                                                                                                                                
remote: Enumerating objects: 206, done.                                                                                                                                                                                                                       
remote: Counting objects: 100% (206/206), done.                                                                                                                                                                                                               
remote: Compressing objects: 100% (93/93), done.                                                                                                                                                                                                              
remote: Total 1314 (delta 143), reused 163 (delta 113), pack-reused 1108                                                                                                                                                                                      
Receiving objects: 100% (1314/1314), 114.38 KiB | 179.00 KiB/s, done.                                                                                                                                                                                         
Resolving deltas: 100% (1025/1025), done.                                                                                                                                                                                                                     
Current deployed production HASH: bb029f42f2209a8bde284c7c81c53827b543d801                                                                                                                                                                                    
make: *** [Makefile:27: build-catalog-image] Error 1  
```