### PR TITLE
Silence (temporarily) Redhat ODS volume alerts

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -181,6 +181,10 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// elasticsearch: route any ES alert to PD
 		// https://issues.redhat.com/browse/OSD-3326
 		{Receiver: receiverPagerduty, Match: map[string]string{"cluster": "elasticsearch", "prometheus": "openshift-monitoring/k8s"}},
+
+		// Suppress these alerts while sd-cssre moves the RHODS addon to non-"redhat*-" namespace
+		// TODO: This can be removed when RHODS-280 is completed
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubePersistentVolumeUsageCriticalLayeredProduct", "namespace": "redhat-ods-applications"}},
 	}
 
 	return &alertmanager.Route{


### PR DESCRIPTION
Temporarily silence `KubePersistentVolumeUsageCriticalLayeredProduct`
alerts in the `redhat-ods-applications` namespaces while cssre works to
move these volumes to non-redhat* namespaces.

Alerts are unactionable by SREP/CSSRE: customers filling their own PVs

This can be removed when [RHODS-280](https://issues.redhat.com/browse/RHODS-280) is completed.

REF: [RHODS-280](https://issues.redhat.com/browse/RHODS-280)

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
