### PR TITLE
Use IMAGE_DIGEST in OLM template

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -9,10 +9,7 @@ parameters:
 - name: CHANNEL
   value: staging
   required: true
-- name: IMAGE_TAG
-  value: latest
-  required: true
-- name: REPO_DIGEST
+- name: IMAGE_DIGEST
   required: true
 
 objects:
@@ -36,7 +33,7 @@ objects:
         name: configure-alertmanager-operator-registry
         namespace: openshift-monitoring
       spec:
-        image: ${REPO_DIGEST}
+        image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
To make the OLM template easier to understand, replace `${REPO_DIGEST}` with `${REGISTRY_IMG}@${IMAGE_DIGEST}`.

`IMAGE_DIGEST` is supported as of APPSRE-3265.