### PR TITLE
Silence UWM Prometheus customer misconfig alerts

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -191,6 +191,9 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-6951
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-redhat-marketplace"}},
 
+		// https://issues.redhat.com/browse/OSD-6821
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusBadConfig", "namespace": "openshift-user-workload-monitoring"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusDuplicateTimestamps", "namespace": "openshift-user-workload-monitoring"}},
 	}
 
 	return &alertmanager.Route{


### PR DESCRIPTION
Customers configure ServiceMonitors and PodMonitors for UWM.
If they are misconfigured then its not on us to fix it.
These alerts should not alert SREP.

REF: [OSD-6821](https://issues.redhat.com/browse/OSD-6821)