### PR TITLE
Stop filtering based on `namespace` label

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -170,9 +170,9 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},
 
 
-		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
+		{Receiver: receiverPagerduty, Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
 		// general: route anything in core namespaces to PD
-		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
+		{Receiver: receiverPagerduty, Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
 
 		// Suppress these alerts while sd-cssre moves the RHODS addon to non-"redhat*-" namespace
 		// TODO: This can be removed when RHODS-280 is completed

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -171,9 +171,9 @@ func createPagerdutyRoute() *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/OSD-3086
 		// https://issues.redhat.com/browse/OSD-5872
-		{Receiver: receiverPagerduty, MatchRE: map[string]string{"exported_namespace": alertmanager.PDRegex}, Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
+		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
 		// general: route anything in core namespaces to PD
-		{Receiver: receiverPagerduty, MatchRE: map[string]string{"namespace": alertmanager.PDRegex}, Match: map[string]string{"exported_namespace": "", "prometheus": "openshift-monitoring/k8s"}},
+		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"exported_namespace": "", "prometheus": "openshift-monitoring/k8s"}},
 		// fluentd: route any fluentd alert to PD
 		// https://issues.redhat.com/browse/OSD-3326
 		{Receiver: receiverPagerduty, Match: map[string]string{"job": "fluentd", "prometheus": "openshift-monitoring/k8s"}},

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -173,7 +173,7 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-5872
 		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
 		// general: route anything in core namespaces to PD
-		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"exported_namespace": "", "prometheus": "openshift-monitoring/k8s"}},
+		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
 		// fluentd: route any fluentd alert to PD
 		// https://issues.redhat.com/browse/OSD-3326
 		{Receiver: receiverPagerduty, Match: map[string]string{"job": "fluentd", "prometheus": "openshift-monitoring/k8s"}},

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -169,18 +169,10 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-1922
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},
 
-		// https://issues.redhat.com/browse/OSD-3086
-		// https://issues.redhat.com/browse/OSD-5872
+
 		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
 		// general: route anything in core namespaces to PD
 		{Receiver: receiverPagerduty, MatchRE: map[string]string{Match: map[string]string{"prometheus": "openshift-monitoring/k8s"}},
-		// fluentd: route any fluentd alert to PD
-		// https://issues.redhat.com/browse/OSD-3326
-		{Receiver: receiverPagerduty, Match: map[string]string{"job": "fluentd", "prometheus": "openshift-monitoring/k8s"}},
-		{Receiver: receiverPagerduty, Match: map[string]string{"alertname": "FluentdNodeDown", "prometheus": "openshift-monitoring/k8s"}},
-		// elasticsearch: route any ES alert to PD
-		// https://issues.redhat.com/browse/OSD-3326
-		{Receiver: receiverPagerduty, Match: map[string]string{"cluster": "elasticsearch", "prometheus": "openshift-monitoring/k8s"}},
 
 		// Suppress these alerts while sd-cssre moves the RHODS addon to non-"redhat*-" namespace
 		// TODO: This can be removed when RHODS-280 is completed


### PR DESCRIPTION
only core namespaces are watched anyway by cluster monitoring.
Filtering solely based on alerts originating from the main prometheus is good enough and ensures we get all alerts.

With the current filtering we are missing alert like https://github.com/openshift/machine-config-operator/blob/release-4.6/install/0000_90_machine-config-operator_01_prometheus-rules.yaml that don't have a namespace label but we definitely care about