### PR TITLE
Revert "redirect the warnings for etcd to null"

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -135,8 +135,6 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ImagePruningDisabled"}},
 		// https://issues.redhat.com/browse/OSD-3794
 		{Receiver: receiverNull, Match: map[string]string{"severity": "info"}},
-		// https://issues.redhat.com/browse/OSD-4631
-		{Receiver: receiverNull, MatchRE: map[string]string{"alertname": "^etcd.*"}, Match: map[string]string{"severity": "warning"}},
 		// https://issues.redhat.com/browse/OSD-3973
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "PodDisruptionBudgetLimit"}},
 		// https://issues.redhat.com/browse/OSD-3973


### PR DESCRIPTION
Reverts openshift/configure-alertmanager-operator#94

We want those warning alerts back.
Everyone should have their personal settings in a way that their not paged on the weekend for warnings.
Additionally we are going to work with the etcd team to tune the alerts appropriately and work  together to get runbooks that enable SRE to resolve those alerts. 