### PR TITLE
route openshift-operators-redhat to devnull

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -129,6 +129,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-operators"}},
 		// https://issues.redhat.com/browse/OSD-6505
 		{Receiver: receiverNull, Match: map[string]string{"exported_namespace": "openshift-operators"}},
+		// https://issues.redhat.com/browse/OSD-7653
+		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-operators-redhat"}},
 		// https://issues.redhat.com/browse/OSD-3629
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CustomResourceDetected"}},
 		// https://issues.redhat.com/browse/OSD-3629


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-7653 
SREP should not get alerted from anything eminating from this namespace.