### PR TITLE
Added alerts to dev/null receiver

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -198,6 +198,10 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-6821
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusBadConfig", "namespace": "openshift-user-workload-monitoring"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusDuplicateTimestamps", "namespace": "openshift-user-workload-monitoring"}},
+
+		//https://issues.redhat.com/browse/OSD-7671
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentdQueueLengthBurst", "namespace": "openshift-logging", "severity": "warning"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "FailingOperator", "namespace": "openshift-operator-lifecycle-manager", "severity": "warning"}},
 	}
 
 	return &alertmanager.Route{


### PR DESCRIPTION
This pr adds the following alerts with severity warning to dev/null receiver per https://issues.redhat.com/browse/OSD-7671

-- FluentdQueueLengthBurst
-- FailingOperator