### PR TITLE
Added failingOperator alerts to dev/null receiver

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -201,6 +201,7 @@ func createPagerdutyRoute() *alertmanager.Route {
 
 		//https://issues.redhat.com/browse/OSD-7671
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentdQueueLengthBurst", "namespace": "openshift-logging", "severity": "warning"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "FailingOperator", "namespace": "openshift-operator-lifecycle-manager", "severity": "warning"}},
 	}
 
 	return &alertmanager.Route{


### PR DESCRIPTION
This pr adds the following alerts with severity warning to dev/null receiver per https://issues.redhat.com/browse/OSD-7671

-- failingOperator

split from previous PR https://github.com/openshift/configure-alertmanager-operator/pull/170