### PR TITLE
[OSD-7437] Disable KubeJobFailed alert for image-pruner

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -149,6 +149,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "TargetDown"}},
 		// https://issues.redhat.com/browse/OSD-5544
 		{Receiver: receiverNull, MatchRE: map[string]string{"job_name": "^elasticsearch.*"}, Match: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-logging"}},
+		// https://issues.redhat.com/browse/OSD-7437
+		{Receiver: receiverNull, MatchRE: map[string]string{"job_name": "^image-pruner.*"}, Match: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-image-registry"}},
 		// Suppress the alerts and use HAProxyReloadFailSRE instead (openshift/managed-cluster-config#600)
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "HAProxyReloadFail", "severity": "critical"}},
 		// https://issues.redhat.com/browse/OHSS-2163


### PR DESCRIPTION
After dealing with multiple failed job alerts for `image-pruner`, we realized that currently, a single failed image-pruner cronjob isn't indicative of an ongoing issue. This PR disables the upstream `KubeJoFailed` alert for image-pruner. I will send a PR to managed-cluster-config for a custom alert for image-pruner so that an alert won't get triggered until 2 jobs have failed.

PTAL 

See: https://issues.redhat.com/browse/OSD-7437