### PR TITLE
Explicitly redirect auth operator ClusterOperatorDown to null

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -160,6 +160,12 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-6363
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication", "reason": "OAuthServerConfigObservation_Error"}},
 
+		//https://issues.redhat.com/browse/OSD-8320
+		// Sometimes only CLusterOperatorDown is firing, meaning the suppression set below in this file does not work
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "IdentityProviderConfig_Error"}},
+		//https://issues.redhat.com/browse/OSD-8320
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "OAuthServerConfigObservation_Error"}},
+
 		// https://issues.redhat.com/browse/OSD-6327
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CannotRetrieveUpdates"}},
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-8320

There is an alert suppression configuration that prevents ClusterOperatorDown from firing if ClusterOperatorDegraded is also firing. Recently we've seen some cases where only ClusterOperatorDown is firing for the auth operator, meaning it does not get suppressed. This explicitly redirects those alerts to null