### PR TITLE
Silences OLM alerts for `openshift-storage` namespace

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -131,6 +131,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-pipelines"}},
 		// https://issues.redhat.com/browse/OSD-8337
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-storage"}},
+		// https://issues.redhat.com/browse/OSD-8349
+		{Receiver: receiverNull, Match: map[string]string{"exported_namespace": "openshift-storage"}},
 		// https://issues.redhat.com/browse/OSD-7747
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-cnv"}},
 		// https://issues.redhat.com/browse/OSD-6505


### PR DESCRIPTION
This silences OLM `CsvAbnormalReplacing...` alerts (or others) coming
from the `openshift-storage` namespace.

fixes [OSD-8349](https://issues.redhat.com/browse/OSD-8349)

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
