### PR TITLE
OSD-8649 devnull HighlyAvailableWorkloadIncorrectlySpread

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -139,6 +139,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CustomResourceDetected"}},
 		// https://issues.redhat.com/browse/OSD-3629
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ImagePruningDisabled"}},
+		// https://issues.redhat.com/browse/OSD-8649
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "HighlyAvailableWorkloadIncorrectlySpread", "severity": "warning"}},
 		// https://issues.redhat.com/browse/OSD-3794
 		{Receiver: receiverNull, Match: map[string]string{"severity": "info"}},
 		// https://issues.redhat.com/browse/OSD-3973


### PR DESCRIPTION
* SRE has a cj that resolves this
* Alert is a no-op
* If the job fails, we an alert for free