### PR TITLE
Ignores Alerts for CsvAbnormalFailedOver2Min for redhat-ods-operator 

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -216,6 +216,9 @@ func createPagerdutyRoute() *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-6821
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusBadConfig", "namespace": "openshift-user-workload-monitoring"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusDuplicateTimestamps", "namespace": "openshift-user-workload-monitoring"}},
+
+		// https://issues.redhat.com/browse/OSD-8689
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "CsvAbnormalFailedOver2Min", "exported_namespace:": "redhat-ods-operator"}},
 	}
 
 	return &alertmanager.Route{


### PR DESCRIPTION
Since the issue is bubbled up to the customer already, there's no reason we should get this alert. [OSD-8689](https://issues.redhat.com/browse/OSD-8689)