### PR TITLE
OSD-8702 send alerts on openshift-compliance to receiverNull

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -127,6 +127,8 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-pipelines"}},
 		// https://issues.redhat.com/browse/OSD-8337
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-storage"}},
+		// https://issues.redhat.com/browse/OSD-8702
+		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-compliance"}},
 		// https://issues.redhat.com/browse/OSD-8349
 		{Receiver: receiverNull, Match: map[string]string{"exported_namespace": "openshift-storage"}},
 		// https://issues.redhat.com/browse/OSD-7747


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-8702
We dont support operatorhub installed `compliance operator` operatorhub, it should not alert us.