### PR TITLE
Fixes typo in alert silence causing error in cluster consoles

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -218,7 +218,7 @@ func createPagerdutyRoute() *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusDuplicateTimestamps", "namespace": "openshift-user-workload-monitoring"}},
 
 		// https://issues.redhat.com/browse/OSD-8689
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "CsvAbnormalFailedOver2Min", "exported_namespace:": "redhat-ods-operator"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "CsvAbnormalFailedOver2Min", "exported_namespace": "redhat-ods-operator"}},
 	}
 
 	return &alertmanager.Route{


### PR DESCRIPTION
An extra ":" in one of the alert silences is causing the alertmanager
operator to fail to reconcile, with an "invalid label name" error, which
causes an alert/warning to be visible in the cluster console.

This removes the extra ":", which causes the label name to fail
validation via the Prometheus label name regex, from the string.

REF: https://issues.redhat.com/browse/OSD-8717
REF: https://github.com/openshift/configure-alertmanager-operator/commit/9bd5a951327d2c565d845acc352441ad601a9952

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
