### PR TITLE
Route alerts with improper severity to 'null'

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -241,6 +241,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/OSD-8689
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CsvAbnormalFailedOver2Min", "exported_namespace": "redhat-ods-operator"}},
+
+		// https://issues.redhat.com/browse/OSD-9062
+		{Receiver: receiverNull, Match: map[string]string{"severity": "alert"}},
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
If alerts have malformed severities, they will cause 400 errors from the PD api, and errors from alertmanager.

fixes [OSD-9062](https://issues.redhat.com/browse/OSD-9062)