### PR TITLE
Also catch severity=error

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -210,7 +210,7 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		//https://issues.redhat.com/browse/OSD-7671
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentdQueueLengthBurst", "namespace": "openshift-logging", "severity": "warning"}},
 		//https://issues.redhat.com/browse/OSD-8403, https://issues.redhat.com/browse/OSD-8576
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentdQueueLengthIncreasing", "namespace": "openshift-logging", "severity": "warning"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentdQueueLengthIncreasing", "namespace": "openshift-logging"}},
 
 		// Suppress these alerts while sd-cssre moves the RHODS addon to non-"redhat*-" namespace
 		// TODO: This can be removed when RHODS-280 is completed


### PR DESCRIPTION
This alert also fires as an error level alert, so let's route this to /dev/null for any severity level.