### PR TITLE
OSD-9239 Add a deployment parameter OLM template for fedramp

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -11,6 +11,8 @@ parameters:
   required: true
 - name: IMAGE_DIGEST
   required: true
+- name: FEDRAMP
+  value: "false"
 
 objects:
 - apiVersion: hive.openshift.io/v1
@@ -62,6 +64,10 @@ objects:
         name: configure-alertmanager-operator
         source: configure-alertmanager-operator-registry
         sourceNamespace: openshift-monitoring
+      config:
+        env:
+        - name: FEDRAMP
+          value: "${FEDRAMP}"
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/deploy/04_operator.yaml
+++ b/deploy/04_operator.yaml
@@ -43,3 +43,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "configure-alertmanager-operator"
+            - name: FEDRAMP
+              value: "false"

--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -3,6 +3,8 @@ package secret
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -594,6 +596,18 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 
 	reqLogger := log.WithValues("Request.Name", request.Name)
 	reqLogger.Info("Reconciling Object")
+
+	//FEDRAMP environment variable defaulting to false.
+	fedramp := false
+	if fedrampVar, ok := os.LookupEnv("FEDRAMP"); ok {
+		fedramp, err := strconv.ParseBool(fedrampVar)
+		if err != nil {
+			reqLogger.Info("Unable to parse FEDRAMP environment variable. defaulting to %b.", fedramp)
+		}
+		reqLogger.Info("running in FedRAMP environment: %b", fedramp)
+	} else {
+		reqLogger.Info("FedRAMP environment variable unset, defaulting to %b", fedramp)
+	}
 
 	// This operator is only interested in the 3 secrets & 1 configMap listed below. Skip reconciling for all other objects.
 	// TODO: Filter these with a predicate instead


### PR DESCRIPTION
This closes [OSD-9239](https://issues.redhat.com/browse/OSD-9239):

added to the OLM template, such that AppSRE can deploy the operator in different govcloud vs. non-govcloud environments.