### PR TITLE
OSD-9383 route sev=none to dev/null

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -256,6 +256,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/OSD-9062
 		{Receiver: receiverNull, Match: map[string]string{"severity": "alert"}},
+
+		// https://issues.redhat.com/browse/OSD-9383
+		{Receiver: receiverNull, Match: map[string]string{"severity": "none"}},
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
Watchdog attempts to send an alert to PD with severity = none. This causes AM to raise an alert as PD rejects this. 

```
Warning Alerts:
{
  "alertname": "AlertmanagerReceiversNotConfigured",
  "job": null,
  "namespace": "openshift-monitoring",
  "exported_namespace": null,
  "pod": null,
  "service": null,
  "alertstate": "firing"
}
```

This PR ensures alerts with severity=none are routed to /dev/null to avoid "noise" on the pager. 