### PR TITLE
Improve FedRAMP logging

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -597,16 +597,17 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	reqLogger := log.WithValues("Request.Name", request.Name)
 	reqLogger.Info("Reconciling Object")
 
-	//FEDRAMP environment variable defaulting to false.
+	// FEDRAMP environment check
+	// TODO: Add cluster info anonymization if FEDRAMP is true
 	fedramp := false
 	if fedrampVar, ok := os.LookupEnv("FEDRAMP"); ok {
 		fedramp, err := strconv.ParseBool(fedrampVar)
 		if err != nil {
-			reqLogger.Info("Unable to parse FEDRAMP environment variable. defaulting to %b.", fedramp)
+			reqLogger.Info("Unable to parse FEDRAMP environment variable, defaulting to %t.", fedramp)
 		}
-		reqLogger.Info("running in FedRAMP environment: %b", fedramp)
+		reqLogger.Info("FedRAMP environment: %t", fedramp)
 	} else {
-		reqLogger.Info("FedRAMP environment variable unset, defaulting to %b", fedramp)
+		reqLogger.Info("FedRAMP environment variable unset, defaulting to %t", fedramp)
 	}
 
 	// This operator is only interested in the 3 secrets & 1 configMap listed below. Skip reconciling for all other objects.


### PR DESCRIPTION
Reduce confusion around logging the FedRAMP variable. Use correct syntax for printing boolean.