### PR TITLE
put severity=alert before cluster=elasticsearch

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -223,6 +223,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-9061
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterAutoscalerUnschedulablePods", "namespace": "openshift-machine-api"}},
 
+		// https://issues.redhat.com/browse/OSD-9062
+		{Receiver: receiverNull, Match: map[string]string{"severity": "alert"}},
+
 		// https://issues.redhat.com/browse/OSD-1922
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},
 
@@ -253,9 +256,6 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/OSD-8689
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CsvAbnormalFailedOver2Min", "exported_namespace": "redhat-ods-operator"}},
-
-		// https://issues.redhat.com/browse/OSD-9062
-		{Receiver: receiverNull, Match: map[string]string{"severity": "alert"}},
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
After https://github.com/openshift/configure-alertmanager-operator/pull/200 being promoted, we still see AlertmanagerFailedToSendAlerts .


The order in the AM routes matters. The `severity=alert` is caught by `cluster=elasticsearch` which sends to PD.
https://github.com/openshift/configure-alertmanager-operator/blob/b2122556e52efba467f454e0ee25815b702f0bc5/pkg/controller/secret/secret_controller.go#L235


Moving the `severity=alert` route before `cluster=elasticsearch` to make it work as expected.