### PR TITLE
Adding PrometheusTargetSyncFailure alert to silence in UWM

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -251,6 +251,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusBadConfig", "namespace": "openshift-user-workload-monitoring"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusDuplicateTimestamps", "namespace": "openshift-user-workload-monitoring"}},
 
+		// https://issues.redhat.com/browse/OSD-9426
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusTargetSyncFailure", "namespace": "openshift-user-workload-monitoring"}},
+
 		// https://issues.redhat.com/browse/OSD-8689
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CsvAbnormalFailedOver2Min", "exported_namespace": "redhat-ods-operator"}},
 


### PR DESCRIPTION
Adding PrometheusTargetSyncFailure alert to silence in UWM as per [OSD-9426](https://issues.redhat.com/browse/OSD-9426). 