### PR TITLE
Fix fedramp logic and log formatting

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -606,11 +606,14 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	if fedrampVar, ok := os.LookupEnv("FEDRAMP"); ok {
 		fedramp, err := strconv.ParseBool(fedrampVar)
 		if err != nil {
-			reqLogger.Info("Unable to parse FEDRAMP environment variable, defaulting to %t.", fedramp)
+			reqLogger.Info("FedRAMP environment variable unable to be parsed", "fedramp", fedramp)
 		}
-		reqLogger.Info("FedRAMP environment: %t", fedramp)
+
+		if fedramp {
+			reqLogger.Info("FedRAMP environment", "fedramp", fedramp)
+		}
 	} else {
-		reqLogger.Info("FedRAMP environment variable unset, defaulting to %t", fedramp)
+		reqLogger.Info("FedRAMP environment variable unset", "fedramp", fedramp)
 	}
 
 	// This operator is only interested in the 3 secrets & 1 configMap listed below. Skip reconciling for all other objects.


### PR DESCRIPTION
Fix fedramp logic and log formatting.

Tested with a staging cluster in both standard and fedramp mode by modifying the deployment field. While in fedramp mode the logs now show correctly, eg `{"level":"info","ts":1643664174.7293966,"logger":"secret_controller","msg":"FedRAMP environment","Request.Name":"prometheus-k8s-dockercfg-kwgfg","fedramp":true}`