### PR TITLE
[OSD-10014] remove prom alerts

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -199,11 +199,6 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		//https://issues.redhat.com/browse/OSD-6559
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusNotIngestingSamples", "namespace": "openshift-user-workload-monitoring"}},
 
-		//https://issues.redhat.com/browse/OSD-6704
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusRemoteStorageFailures", "namespace": "openshift-monitoring"}},
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusRemoteWriteDesiredShards", "namespace": "openshift-monitoring"}},
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusRemoteWriteBehind", "namespace": "openshift-monitoring"}},
-
 		//https://issues.redhat.com/browse/OSD-7671
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentdQueueLengthBurst", "namespace": "openshift-logging", "severity": "warning"}},
 		//https://issues.redhat.com/browse/OSD-8403, https://issues.redhat.com/browse/OSD-8576


### PR DESCRIPTION
These alerts are no longer firing due to upstream observatorium stability. There are 3 clusters firing , they are all private link thus it would expected that observatorium.api.openshift.com has no egress available as per: https://docs.openshift.com/rosa/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites 

```
https://infogw-proxy.api.openshift.com/graph?g0.expr=count%20by(alertname%2C%20_id)%20(alerts%7Balertname%3D~%22PrometheusRemote.%2B%22%7D%20%2Bon(_id)%20group_left(managed)%20(max%20by%20(_id)(subscription_labels%7Bmanaged%3D%22true%22%7D)))&g0.tab=1&g0.stacked=0&g0.range_input=1h&g0.max_source_resolution=0s&g0.deduplicate=1&g0.partial_response=0&g0.store_matches=%5B%5D 
```

Service Logs can be sent to these clusters 