### PR TITLE
[OSD-10077]Only mute ClusterOperatorDown when ClusterOperatorDegraded is critical

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -413,6 +413,7 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, clusterID string
 				},
 				SourceMatch: map[string]string{
 					"alertname": "ClusterOperatorDegraded",
+					"severity":  "critical",
 				},
 				TargetMatchRE: map[string]string{
 					"alertname": "ClusterOperatorDown",

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -278,6 +278,7 @@ func verifyInhibitRules(t *testing.T, inhibitRules []*alertmanager.InhibitRule) 
 			},
 			SourceMatch: map[string]string{
 				"alertname": "ClusterOperatorDegraded",
+				"severity":  "critical",
 			},
 			TargetMatchRE: map[string]string{
 				"alertname": "ClusterOperatorDown",


### PR DESCRIPTION
Resolve [OSD-10077](https://issues.redhat.com/browse/OSD-10077)