### PR TITLE
OSD-10473 - Downgrade ExtremelyHighIndividualControlPlaneCPU to warning

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -263,6 +263,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/OSD-8983
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "etcdGRPCRequestsSlow", "namespace": "openshift-etcd"}},
+
+		// https://issues.redhat.com/browse/OSD-10473
+		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU", "namespace": "openshift-kube-apiserver"}},
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-10473

---

Downgrades `ExtremelyHighIndividualControlPlaneCPU` as this doesn't necessarily indicate an issue with the cluster and often has no associated actions for primary to take.

Further discussion: https://coreos.slack.com/archives/G01DC1VRAGK/p1648062765841089