### PR TITLE
[OSD-10485] Lower Sev of etcdHighNumberOfFailedGRPCRequests to warning

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -267,6 +267,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/OSD-10473
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU", "namespace": "openshift-kube-apiserver"}},
+
+		// https://issues.redhat.com/browse/OSD-10485
+		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "etcdHighNumberOfFailedGRPCRequests", "namespace": "openshift-etcd"}},
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
`etcdHighNumberOfFailedGRPCRequests` has been the noisiest alert for the past few weeks without any action for on call SRE as it almost always self resolves in 5 minutes without intervention.

This is similar to https://github.com/openshift/configure-alertmanager-operator/pull/215

More explanation in https://issues.redhat.com/browse/OSD-10485