### PR TITLE
OSD-10936 Use a proxy for DMS/PD comms, if configured

### DIFF
--- a/deploy/01_role.yaml
+++ b/deploy/01_role.yaml
@@ -62,6 +62,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - proxies
+  verbs:
+    - get
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/pkg/types/alertmanagerconfig.go
+++ b/pkg/types/alertmanagerconfig.go
@@ -110,6 +110,18 @@ type Route struct {
 	RepeatInterval string `yaml:"repeat_interval,omitempty" json:"repeat_interval,omitempty"`
 }
 
+type HttpConfig struct {
+	ProxyURL  string    `yaml:"proxy_url,omitempty" json:"proxy_url,omitempty"`
+	TLSConfig TLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+}
+
+type TLSConfig struct {
+	CAFile             string `yaml:"ca_file,omitempty" json:"ca_file,omitempty"`
+	KeyFile            string `yaml:"key_file,omitempty" json:"key_file,omitempty"`
+	ServerName         string `yaml:"server_name,omitempty" json:"server_name,omitempty"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify,omitempty" json:"insecure_skip_verify,omitempty"`
+}
+
 type Receiver struct {
 	// A unique identifier for this receiver.
 	Name string `yaml:"name" json:"name"`
@@ -124,6 +136,8 @@ type WebhookConfig struct {
 
 	// URL to send POST request to.
 	URL string `yaml:"url" json:"url"`
+
+	HttpConfig HttpConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 }
 
 type PagerdutyConfig struct {
@@ -139,6 +153,7 @@ type PagerdutyConfig struct {
 	Class       string            `yaml:"class,omitempty" json:"class,omitempty"`
 	Component   string            `yaml:"component,omitempty" json:"component,omitempty"`
 	Group       string            `yaml:"group,omitempty" json:"group,omitempty"`
+	HttpConfig  HttpConfig        `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 }
 
 type NamespaceConfig struct {


### PR DESCRIPTION
This PR adds the ability for CAMO to configure the `http_config` section of PagerDuty and DeadMansSnitch receivers to use a cluster-wide proxy if a HTTPS Proxy is found to be configured on a cluster.

This change is needed to handle scenarios where a cluster blocks all Internet-egress traffic that does not traverse via a proxy; in these situations comms to DMS/PD will be impacted as they do not travel via the proxy by default.

An additional permission has been added to CAMO's ClusterRole to be able to read the cluster's `proxy` resource.

Tests have been updated to check and verify the presence of the proxy in the resulting configs.

This change has been successfully tested in staging to verify that
- DMS and PD comms via a proxy configured in this manner are successful
- clusters without a proxy are not impacted

Refs [OSD-10936](https://issues.redhat.com//browse/OSD-10936)