### PR TITLE
Correcting indentation for config portion of olm template

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -64,10 +64,10 @@ objects:
         name: configure-alertmanager-operator
         source: configure-alertmanager-operator-registry
         sourceNamespace: openshift-monitoring
-      config:
-        env:
-        - name: FEDRAMP
-          value: "${FEDRAMP}"
+        config:
+          env:
+          - name: FEDRAMP
+            value: "${FEDRAMP}"
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
The config portion of the subscription definition in the OLM template wasn't indented far enough, so that portion of the subscription was missing when deployed. Adding that indentation back so that the FEDRAMP variable is set in the subscription object. 