### PR TITLE
Silence PrometheusOperatorRejectedResources from UWM

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -271,6 +271,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		// https://issues.redhat.com/browse/OSD-9426
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusTargetSyncFailure", "namespace": "openshift-user-workload-monitoring"}},
 
+		// https://issues.redhat.com/browse/OSD-11478
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusOperatorRejectedResources", "namespace": "openshift-user-workload-monitoring"}},
+
 		// https://issues.redhat.com/browse/OSD-8983
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "etcdGRPCRequestsSlow", "namespace": "openshift-etcd"}},
 


### PR DESCRIPTION
In OCP 4.10, the PrometheusOperatorRejectedResources alert (along with other alerts related to Prometheus operator) has been extended to cover the openshift-user-workload-monitoring namespace. 

Which means this alert now triggers on some invalid user–defined pod/service monitors.

Those aren't actionable by SRE (they're user–defined), therefore we shouldn't be getting alerted for them.

[OSD-11478](https://issues.redhat.com//browse/OSD-11478)