### PR TITLE
Don't route alerts for addon namespaces

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -38,8 +38,6 @@ const (
 
 	cmKeyOCPNamespaces = "managed_namespaces.yaml"
 
-	cmKeyAddonsNamespaces = "managed_namespaces.yaml"
-
 	secretNamePD = "pd-secret"
 
 	secretNameDMS = "dms-secret"
@@ -49,8 +47,6 @@ const (
 	cmNameManagedNamespaces = "managed-namespaces"
 
 	cmNameOCPNamespaces = "ocp-namespaces"
-
-	cmNameAddonsNamespaces = "addons-namespaces"
 
 	// anything routed to "null" receiver does not get routed to PD
 	receiverNull = "null"
@@ -598,19 +594,16 @@ func (r *ReconcileSecret) parseConfigMaps(reqLogger logr.Logger, cmList *corev1.
 	// Retrieve namespaces from their respective configMaps, if the configMaps exist
 	managedNamespaces := r.parseNamespaceConfigMap(reqLogger, cmNameManagedNamespaces, cmNamespace, cmKeyManagedNamespaces, cmList)
 	ocpNamespaces := r.parseNamespaceConfigMap(reqLogger, cmNameOCPNamespaces, cmNamespace, cmKeyOCPNamespaces, cmList)
-	addonsNamespaces := r.parseNamespaceConfigMap(reqLogger, cmNameAddonsNamespaces, cmNamespace, cmKeyAddonsNamespaces, cmList)
 
 	// Default to alerting on all ^openshift-.* namespaces if either list is empty, potentially indicating a problem parsing configMaps
 	if len(managedNamespaces) == 0 ||
-		len(ocpNamespaces) == 0 ||
-		len(addonsNamespaces) == 0 {
+		len(ocpNamespaces) == 0 {
 		reqLogger.Info("DEBUG: Could not retrieve namespaces from one or more configMaps. Using default namespaces", "Default namespaces", defaultNamespaces)
 		return defaultNamespaces
 	}
 
 	namespaceList = append(namespaceList, managedNamespaces...)
 	namespaceList = append(namespaceList, ocpNamespaces...)
-	namespaceList = append(namespaceList, addonsNamespaces...)
 
 	return namespaceList
 }
@@ -713,7 +706,6 @@ func (r *ReconcileSecret) Reconcile(request reconcile.Request) (reconcile.Result
 	case cmNameOcmAgent:
 	case cmNameManagedNamespaces:
 	case cmNameOCPNamespaces:
-	case cmNameAddonsNamespaces:
 	default:
 		reqLogger.Info("Skip reconcile: No changes detected to alertmanager secrets.")
 		return reconcile.Result{}, nil

--- a/pkg/controller/secret/secret_controller_test.go
+++ b/pkg/controller/secret/secret_controller_test.go
@@ -46,14 +46,6 @@ var exampleOCPNamespaces = []string{
 	"openshift-cloud-credential-operator",
 }
 
-var exampleAddonsNamespaces = []string{
-	"acm",
-	"addon-dba-operator",
-	"codeready-workspaces-operator",
-	"codeready-workspaces-operator-qe",
-	"openshift-logging",
-}
-
 // readAlertManagerConfig fetches the AlertManager configuration from its default location.
 // This is equivalent to `oc get secrets -n openshift-monitoring alertmanager-main`.
 // It specifically extracts the .data "alertmanager.yaml" field, and loads it into a resource
@@ -558,7 +550,6 @@ func Test_parseConfigMaps(t *testing.T) {
 	var validNamespaces []string
 	validNamespaces = append(validNamespaces, exampleManagedNamespaces...)
 	validNamespaces = append(validNamespaces, exampleOCPNamespaces...)
-	validNamespaces = append(validNamespaces, exampleAddonsNamespaces...)
 
 	// Convert to regex to match the result of parseConfigMaps()
 	for i, ns := range validNamespaces {
@@ -576,7 +567,6 @@ func Test_parseConfigMaps(t *testing.T) {
 		expectedNamespaces []string
 		managedNamespace   configMapTest
 		ocpNamespaces      configMapTest
-		addonsNamespaces   configMapTest
 	}{
 		{
 			name:               "Valid configMaps",
@@ -586,10 +576,6 @@ func Test_parseConfigMaps(t *testing.T) {
 				missing: false,
 			},
 			ocpNamespaces: configMapTest{
-				invalid: false,
-				missing: false,
-			},
-			addonsNamespaces: configMapTest{
 				invalid: false,
 				missing: false,
 			},
@@ -605,10 +591,6 @@ func Test_parseConfigMaps(t *testing.T) {
 				invalid: false,
 				missing: false,
 			},
-			addonsNamespaces: configMapTest{
-				invalid: false,
-				missing: false,
-			},
 		},
 		{
 			name:               "Missing managed-namespaces configMap",
@@ -618,10 +600,6 @@ func Test_parseConfigMaps(t *testing.T) {
 				missing: true,
 			},
 			ocpNamespaces: configMapTest{
-				invalid: false,
-				missing: false,
-			},
-			addonsNamespaces: configMapTest{
 				invalid: false,
 				missing: false,
 			},
@@ -637,10 +615,6 @@ func Test_parseConfigMaps(t *testing.T) {
 				invalid: true,
 				missing: false,
 			},
-			addonsNamespaces: configMapTest{
-				invalid: false,
-				missing: false,
-			},
 		},
 		{
 			name:               "Missing ocp-namespaces configMap",
@@ -650,42 +624,6 @@ func Test_parseConfigMaps(t *testing.T) {
 				missing: false,
 			},
 			ocpNamespaces: configMapTest{
-				invalid: false,
-				missing: true,
-			},
-			addonsNamespaces: configMapTest{
-				invalid: false,
-				missing: false,
-			},
-		},
-		{
-			name:               "Invalid addons-namespaces configMap",
-			expectedNamespaces: defaultNamespaces,
-			managedNamespace: configMapTest{
-				invalid: false,
-				missing: false,
-			},
-			ocpNamespaces: configMapTest{
-				invalid: false,
-				missing: false,
-			},
-			addonsNamespaces: configMapTest{
-				invalid: true,
-				missing: false,
-			},
-		},
-		{
-			name:               "Missing addons-namespaces configMap",
-			expectedNamespaces: defaultNamespaces,
-			managedNamespace: configMapTest{
-				invalid: false,
-				missing: false,
-			},
-			ocpNamespaces: configMapTest{
-				invalid: false,
-				missing: false,
-			},
-			addonsNamespaces: configMapTest{
 				invalid: false,
 				missing: true,
 			},
@@ -723,20 +661,6 @@ func Test_parseConfigMaps(t *testing.T) {
 				cmDataOcpNamespaces = "This is an invalid format for the managed-namespaces configmap!"
 			}
 			createConfigMap(reconciler, cmNameOCPNamespaces, cmKeyOCPNamespaces, cmDataOcpNamespaces)
-		}
-
-		// addons-namespaces configMap
-		if !tt.addonsNamespaces.missing {
-			var cmDataAddonsNamespaces string
-			if !tt.addonsNamespaces.invalid {
-				cmDataAddonsNamespaces = "Resources:\n  Namespace:"
-				for _, ns := range exampleAddonsNamespaces {
-					cmDataAddonsNamespaces = cmDataAddonsNamespaces + fmt.Sprintf("\n  - name: '%v'", ns)
-				}
-			} else {
-				cmDataAddonsNamespaces = "This is an invalid format for the managed-namespaces configmap!"
-			}
-			createConfigMap(reconciler, cmNameAddonsNamespaces, cmKeyAddonsNamespaces, cmDataAddonsNamespaces)
 		}
 
 		// Run and verify results

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -58,10 +58,6 @@ var (
 		Name: "ocp_namespaces_configmap_exists",
 		Help: "ocp-namespaces configMap exists",
 	}, []string{"name"})
-	metricAddonsNSConfigMapExists = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "addons_namespaces_configmap_exists",
-		Help: "addons-namespaces configMap exists",
-	}, []string{"name"})
 
 	metricsList = []prometheus.Collector{
 		metricPDSecretExists,
@@ -71,7 +67,6 @@ var (
 		metricAMSecretContainsDMS,
 		metricManNSConfigMapExists,
 		metricOcpNSConfigMapExists,
-		metricAddonsNSConfigMapExists,
 	}
 )
 
@@ -175,7 +170,6 @@ func UpdateConfigMapMetrics(list *corev1.ConfigMapList) {
 	// Default to false.
 	manNsConfigMapExists := false
 	ocpNsConfigMapExists := false
-	addonsNsConfigMapExists := false
 
 	// Update the metric if the configmap is found in the ConfigMapList.
 	for _, configMap := range list.Items {
@@ -184,8 +178,6 @@ func UpdateConfigMapMetrics(list *corev1.ConfigMapList) {
 			manNsConfigMapExists = true
 		case "ocp-namespaces":
 			ocpNsConfigMapExists = true
-		case "addons-namespaces":
-			addonsNsConfigMapExists = true
 		}
 	}
 
@@ -199,10 +191,5 @@ func UpdateConfigMapMetrics(list *corev1.ConfigMapList) {
 		metricOcpNSConfigMapExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(1))
 	} else {
 		metricOcpNSConfigMapExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(0))
-	}
-	if addonsNsConfigMapExists {
-		metricAddonsNSConfigMapExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(1))
-	} else {
-		metricAddonsNSConfigMapExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(0))
 	}
 }


### PR DESCRIPTION
As addons use their own alerting stacks, don't route alerts for these namespaces via the platform's stack.