### PR TITLE
OSD-12234 Display the SOP url in FedRAMP, does not need to be redacted

### DIFF
--- a/pkg/controller/secret/secret_controller.go
+++ b/pkg/controller/secret/secret_controller.go
@@ -373,7 +373,6 @@ func createPagerdutyConfig(pagerdutyRoutingKey, clusterID string, clusterProxy s
 		detailsMap["resolved"] = ``
 		detailsMap["cluster_id"] = ``
 		detailsMap["firing"] = ``
-		detailsMap["link"] = ``
 	}
 
 	return &alertmanager.PagerdutyConfig{


### PR DESCRIPTION
The SOP link is helpful and there is not a FedRAMP control that requires that it is redacted.