### PR TITLE
OSD-12234 Redact client_url for FedRAMP

### DIFF
--- a/pkg/types/alertmanagerconfig.go
+++ b/pkg/types/alertmanagerconfig.go
@@ -140,6 +140,8 @@ type WebhookConfig struct {
 	HttpConfig HttpConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 }
 
+// PagerdutyConfig defines the integration point between AlertManager and PagerDuty
+// https://prometheus.io/docs/alerting/latest/configuration/#pagerduty_config
 type PagerdutyConfig struct {
 	NotifierConfig `yaml:",inline" json:",inline"`
 


### PR DESCRIPTION
It contains the user-supplied cluster name, which cannot leave the boundary due to compliance reasons