### PR TITLE
Route critical DVO namespace alerts to warning

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -377,6 +377,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/OSD-10485
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"alertname": "etcdHighNumberOfFailedGRPCRequests", "namespace": "openshift-etcd"}},
+
+		// https://issues.redhat.com/browse/DVO-54
+		{Receiver: receiverMakeItWarning, Match: map[string]string{"severity": "critical", "namespace": "openshift-deployment-validation-operator"}},
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
This PR routes all critical alerts from the DVO namespace to the warning receiver. This will ensure that such alerts don't flood primary as we roll this component out.

relates to [DVO-54](https://issues.redhat.com//browse/DVO-54)