### PR TITLE
OSD-13721 - Inhibit api-ErrorBudgetBurn when KubeAPIErrorBudgetBurn is firing

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -692,6 +692,18 @@ func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, ocmAgentURL, clu
 					"alertname": "ElasticsearchClusterNotHealthy",
 				},
 			},
+			// https://issues.redhat.com/browse/OSD-13721
+			{
+				Equal: []string{
+					"severity",
+				},
+				SourceMatch: map[string]string{
+					"alertname": "KubeAPIErrorBudgetBurn",
+				},
+				TargetMatchRE: map[string]string{
+					"alertname": "api-ErrorBudgetBurn",
+				},
+			},
 		},
 	}
 

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -389,6 +389,18 @@ func verifyInhibitRules(t *testing.T, inhibitRules []*alertmanager.InhibitRule) 
 			},
 			Expected: true,
 		},
+		{
+			SourceMatch: map[string]string{
+				"alertname": "KubeAPIErrorBudgetBurn",
+			},
+			TargetMatchRE: map[string]string{
+				"alertname": "api-ErrorBudgetBurn",
+			},
+			Equal: []string{
+				"severity",
+			},
+			Expected: true,
+		},
 	}
 
 	// keep track of which inhibition rules were affirmatively tested


### PR DESCRIPTION
Completes: https://issues.redhat.com/browse/OSD-13721

---

These changes add an `inhibitRule` which prevents `api-ErrorBudgetBurn` alerts from firing when a `KubeAPIErrorBudgetBurn` alert has already been triggered.

An inverse rule was not created because `KubeAPIErrorBudgetBurn` alerts are based on the kube-apiservers' internal metrics while `api-ErrorBudgetBurn` alerts are based on the reachability of the kube-apiservers. Firing a `KubeAPIErrorBudget` burn after an `api-ErrorBudgetBurn` is, at this time, believed to indicate a separate issue with the control plane which needs to be addressed individually. 