### PR TITLE
Silence Insights operator down alert in FedRAMP environment

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -388,7 +388,6 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		pagerdutySubroutes = append(pagerdutySubroutes,
 			[]*alertmanager.Route{
 				{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
-				{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "insights"}},
 			}...,
 		)
 	}

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -386,9 +386,8 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 	// https://issues.redhat.com/browse/OSD-13685
 	if config.IsFedramp() {
 		pagerdutySubroutes = append(pagerdutySubroutes,
-			[]*alertmanager.Route{
-				{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
-			}...)
+			&alertmanager.Route{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
+		)
 	}
 
 	for _, namespace := range namespaceList {

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -388,8 +388,7 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		pagerdutySubroutes = append(pagerdutySubroutes,
 			[]*alertmanager.Route{
 				{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
-			}...,
-		)
+			}...)
 	}
 
 	for _, namespace := range namespaceList {

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -382,6 +382,17 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"severity": "critical", "namespace": "openshift-deployment-validation-operator"}},
 	}
 
+	// Silence insights in FedRAMP until its made available in the environment
+	// https://issues.redhat.com/browse/OSD-13685
+	if config.IsFedramp() {
+		pagerdutySubroutes = append(pagerdutySubroutes,
+			[]*alertmanager.Route{
+				{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
+				{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "insights"}},
+			}...,
+		)
+	}
+
 	for _, namespace := range namespaceList {
 		pagerdutySubroutes = append(pagerdutySubroutes, []*alertmanager.Route{
 			// https://issues.redhat.com/browse/OSD-3086


### PR DESCRIPTION
This insights operator is not available in the Fedramp environment yet and it's paging SREPs unnecessarily. This PR silence the ClusterOperatorDown alert for now. It will need to be removed once insights is made available in the environment.
It's been tested in a fedramp cluster successfully
https://issues.redhat.com/browse/OSD-13685
