### PR TITLE
OSD-14071 silence MultipleDefaultStorageClasses

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -380,6 +380,9 @@ func createPagerdutyRoute(namespaceList []string) *alertmanager.Route {
 
 		// https://issues.redhat.com/browse/DVO-54
 		{Receiver: receiverMakeItWarning, Match: map[string]string{"severity": "critical", "namespace": "openshift-deployment-validation-operator"}},
+
+		// https://issues.redhat.com/browse/OSD-14071
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "MultipleDefaultStorageClasses", "namespace": "openshift-cluster-storage-operator"}},
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
# What it does

Routes the `MultipleDefaultStorageClasses` alert to the null AlertManager receiver.

# Why it does it

This alert has been onboarded into OCM Agent via [OSD-14071](https://issues.redhat.com//browse/OSD-14071) / this PR [0].

[0] https://github.com/openshift/managed-cluster-config/pull/1350