### PR TITLE
Linting fixes

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -79,6 +79,7 @@ func StartMetrics() error {
 	}
 	http.Handle("/metrics", promhttp.Handler())
 	// TODO: Check errors from ListenAndServe()
+	//#nosec G114 -- We don't need timeouts for an internal metrics endpoint
 	go func() { _ = http.ListenAndServe(MetricsEndpoint, nil) }()
 	return nil
 }

--- a/pkg/readiness/cluster_ready.go
+++ b/pkg/readiness/cluster_ready.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -66,16 +65,16 @@ const (
 
 // IsReady deals with the osd-cluster-ready Job.
 // Sets:
-// - impl.Ready:
-//   true if:
+//   - impl.Ready:
+//     true if:
 //   - a previous check has already succeeded (a cluster can't become un-ready once it's ready);
 //   - an osd-cluster-ready Job has completed; or
 //   - the cluster is older than maxClusterAgeMinutes
-//   false otherwise.
-// - impl.Result: If the caller's reconcile is otherwise successful, it
-//   should return the given Result.
-// - impl.clusterCreationTime: If it is necessary to check the age of the cluster, this is set so
-//   we only have to query prometheus once.
+//     false otherwise.
+//   - impl.Result: If the caller's reconcile is otherwise successful, it
+//     should return the given Result.
+//   - impl.clusterCreationTime: If it is necessary to check the age of the cluster, this is set so
+//     we only have to query prometheus once.
 func (impl *Impl) IsReady() (bool, error) {
 	if impl.ready {
 		log.Info("DEBUG: Using cached positive cluster readiness.")
@@ -156,7 +155,7 @@ func (impl *Impl) Result() reconcile.Result {
 }
 
 func (impl *Impl) setPromAPI() error {
-	rawToken, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	rawToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 	if err != nil {
 		return fmt.Errorf("couldn't read token file: %w", err)
 	}


### PR DESCRIPTION
This fixes a couple of linting errors:
- ignore G114 for the metrics endpoint as we don't need to worry about enforcing timeouts
- move to `os.ReadFile` instead of `ioutil.ReadFile` which has been deprecated