### PR TITLE
Only configure DMS if PD is being configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 ## Summary
 The Configure Alertmanager Operator was created for the OpenShift Dedicated platform to dynamically manage Alertmanager configurations based on the presence or absence of secrets containing a Pager Duty RoutingKey and [Dead Man's Snitch](https://deadmanssnitch.com) URL. When the secret is created/updated/deleted, the associated Receiver and Route will be created/updated/deleted within the Alertmanager config.
 
+The operator will only configure a Dead Man's Snitch watchdog receiver if a Pager Duty receiver is also configured to be present. This is in order to deliberately trigger a watchdog timeout if for some reason Pager Duty has not been configured, as both are required.  
+
 The operator contains the following components:
 
 * Secret controller: watches the `openshift-monitoring` namespace for any changes to relevant Secrets or ConfigMaps that are used in the configuration of Alertmanager. For more information on this see [Secret Controller](#secret-controller) below.

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -194,7 +194,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	if err != nil {
 		reqLogger.Error(err, "Error reading cluster id.")
 	}
-	alertmanagerconfig := createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, ocmAgentURL, clusterID, clusterProxy, osdNamespaces)
+	alertmanagerconfig := createAlertManagerConfig(reqLogger, pagerdutyRoutingKey, watchdogURL, ocmAgentURL, clusterID, clusterProxy, osdNamespaces)
 
 	// write the alertmanager Config
 	writeAlertManagerConfig(r, reqLogger, alertmanagerconfig)
@@ -559,23 +559,29 @@ func createHttpConfig(clusterProxy string) alertmanager.HttpConfig {
 }
 
 // createAlertManagerConfig creates an AlertManager Config in memory based on the provided input parameters.
-func createAlertManagerConfig(pagerdutyRoutingKey, watchdogURL, ocmAgentURL, clusterID string, clusterProxy string, namespaceList []string) *alertmanager.Config {
+func createAlertManagerConfig(reqLogger logr.Logger, pagerdutyRoutingKey, watchdogURL, ocmAgentURL, clusterID string, clusterProxy string, namespaceList []string) *alertmanager.Config {
 	routes := []*alertmanager.Route{}
 	receivers := []*alertmanager.Receiver{}
 
-	if watchdogURL != "" {
-		routes = append(routes, createWatchdogRoute())
-		receivers = append(receivers, createWatchdogReceivers(watchdogURL, clusterProxy)...)
-	}
-
 	if ocmAgentURL != "" {
+		reqLogger.Info("INFO: Configuring a OCM Agent route and receiver")
 		routes = append(routes, createOCMAgentRoute())
 		receivers = append(receivers, createOCMAgentReceiver(ocmAgentURL)...)
 	}
 
 	if pagerdutyRoutingKey != "" {
+		if watchdogURL != "" {
+			// Only configure a watchdog route if we know that a Pagerduty route is
+			// also being configured (OSD-14347)
+			reqLogger.Info("INFO: Configuring a watchdog route and receiver")
+			routes = append(routes, createWatchdogRoute())
+			receivers = append(receivers, createWatchdogReceivers(watchdogURL, clusterProxy)...)
+		}
+		reqLogger.Info("INFO: Configuring a PagerDuty route and receiver")
 		routes = append(routes, createPagerdutyRoute(namespaceList))
 		receivers = append(receivers, createPagerdutyReceivers(pagerdutyRoutingKey, clusterID, clusterProxy)...)
+	} else {
+		reqLogger.Info("INFO: Not configuring PagerDuty or Dead Man's Snitch receivers")
 	}
 
 	// always have the "null" receiver

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -216,17 +216,35 @@ func verifyPagerdutyReceivers(t *testing.T, key string, proxy string, receivers 
 	assertTrue(t, hasPagerduty, fmt.Sprintf("No '%s' receiver", receiverPagerduty))
 }
 
-// utility function to verify watchdog route
-func verifyWatchdogRoute(t *testing.T, route *alertmanager.Route) {
-	assertEquals(t, receiverWatchdog, route.Receiver, "Receiver Name")
-	assertEquals(t, "5m", route.RepeatInterval, "Repeat Interval")
-	assertEquals(t, "Watchdog", route.Match["alertname"], "Alert Name")
+// utility function to verify no watchdog routes appear in the routes
+func verifyWatchdogRoute(t *testing.T, present bool, routes []*alertmanager.Route) {
+	// There is at least one route
+	if present {
+		assertGte(t, 1, len(routes), "Number of Routes")
+	}
+
+	hasWatchdog := false
+	for _, route := range routes {
+		if route.Receiver == receiverWatchdog {
+			assertEquals(t, "5m", route.RepeatInterval, "Repeat Interval")
+			assertEquals(t, "Watchdog", route.Match["alertname"], "Alert Name")
+			hasWatchdog = true
+		}
+	}
+
+	if present {
+		assertTrue(t, hasWatchdog, fmt.Sprintf("No '%s' route", receiverWatchdog))
+	} else {
+		assertFalse(t, hasWatchdog, fmt.Sprintf("'%s' route found that shouldn't be present", receiverWatchdog))
+	}
 }
 
 // utility to test watchdog receivers
-func verifyWatchdogReceiver(t *testing.T, url string, proxy string, receivers []*alertmanager.Receiver) {
+func verifyWatchdogReceiver(t *testing.T, url string, proxy string, present bool, receivers []*alertmanager.Receiver) {
 	// there is 1 receiver
-	assertGte(t, 1, len(receivers), "Number of Receivers")
+	if present {
+		assertGte(t, 1, len(receivers), "Number of Receivers")
+	}
 
 	// verify structure of each
 	hasWatchdog := false
@@ -239,7 +257,11 @@ func verifyWatchdogReceiver(t *testing.T, url string, proxy string, receivers []
 		}
 	}
 
-	assertTrue(t, hasWatchdog, fmt.Sprintf("No '%s' receiver", receiverWatchdog))
+	if present {
+		assertTrue(t, hasWatchdog, fmt.Sprintf("No '%s' receiver", receiverWatchdog))
+	} else {
+		assertFalse(t, hasWatchdog, fmt.Sprintf("'%s' receiver found that shouldn't be present", receiverWatchdog))
+	}
 }
 
 // utility function to verify watchdog route
@@ -787,7 +809,7 @@ func Test_createWatchdogRoute(t *testing.T) {
 	// test the structure of the Route is sane
 	route := createWatchdogRoute()
 
-	verifyWatchdogRoute(t, route)
+	verifyWatchdogRoute(t, true, []*alertmanager.Route{route})
 }
 
 func Test_createWatchdogReceivers_WithoutURL(t *testing.T) {
@@ -799,7 +821,7 @@ func Test_createWatchdogReceivers_WithKey(t *testing.T) {
 
 	receivers := createWatchdogReceivers(url, exampleProxy)
 
-	verifyWatchdogReceiver(t, url, exampleProxy, receivers)
+	verifyWatchdogReceiver(t, url, exampleProxy, true, receivers)
 }
 
 func Test_createAlertManagerConfig_WithoutKey_WithoutURL(t *testing.T) {
@@ -807,7 +829,7 @@ func Test_createAlertManagerConfig_WithoutKey_WithoutURL(t *testing.T) {
 	wdURL := ""
 	oaURL := ""
 
-	config := createAlertManagerConfig(pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -829,7 +851,7 @@ func Test_createAlertManagerConfig_WithKey_WithoutURL(t *testing.T) {
 	wdURL := ""
 	oaURL := ""
 
-	config := createAlertManagerConfig(pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -853,7 +875,7 @@ func Test_createAlertManagerConfig_WithKey_WithWDURL_WithOAURL(t *testing.T) {
 	pdKey := "poiuqwer78902345"
 	wdURL := "http://theinterwebs"
 	oaURL := "http://dummy-oa-url"
-	config := createAlertManagerConfig(pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -870,10 +892,10 @@ func Test_createAlertManagerConfig_WithKey_WithWDURL_WithOAURL(t *testing.T) {
 	verifyPagerdutyRoute(t, config.Route.Routes[2], exampleManagedNamespaces)
 	verifyPagerdutyReceivers(t, pdKey, exampleProxy, config.Receivers)
 
-	verifyWatchdogRoute(t, config.Route.Routes[0])
-	verifyWatchdogReceiver(t, wdURL, exampleProxy, config.Receivers)
+	verifyWatchdogRoute(t, true, config.Route.Routes)
+	verifyWatchdogReceiver(t, wdURL, exampleProxy, true, config.Receivers)
 
-	verifyOCMAgentRoute(t, config.Route.Routes[1])
+	verifyOCMAgentRoute(t, config.Route.Routes[0])
 	verifyOCMAgentReceiver(t, oaURL, config.Receivers)
 
 	verifyInhibitRules(t, config.InhibitRules)
@@ -884,7 +906,7 @@ func Test_createAlertManagerConfig_WithoutKey_WithoutOA_WithWDURL(t *testing.T) 
 	wdURL := "http://theinterwebs"
 	oaURL := ""
 
-	config := createAlertManagerConfig(pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -893,12 +915,13 @@ func Test_createAlertManagerConfig_WithoutKey_WithoutOA_WithWDURL(t *testing.T) 
 	assertEquals(t, "30s", config.Route.GroupWait, "Route.GroupWait")
 	assertEquals(t, "5m", config.Route.GroupInterval, "Route.GroupInterval")
 	assertEquals(t, "12h", config.Route.RepeatInterval, "Route.RepeatInterval")
-	assertEquals(t, 1, len(config.Route.Routes), "Route.Routes")
-	assertEquals(t, 2, len(config.Receivers), "Receivers")
+	assertEquals(t, 0, len(config.Route.Routes), "Route.Routes")
+	assertEquals(t, 1, len(config.Receivers), "Receivers")
 
 	verifyNullReceiver(t, config.Receivers)
-	verifyWatchdogRoute(t, config.Route.Routes[0])
-	verifyWatchdogReceiver(t, wdURL, exampleProxy, config.Receivers)
+
+	verifyWatchdogRoute(t, false, config.Route.Routes)
+	verifyWatchdogReceiver(t, wdURL, exampleProxy, false, config.Receivers)
 
 	verifyInhibitRules(t, config.InhibitRules)
 }
@@ -984,7 +1007,7 @@ func Test_createPagerdutySecret_Create(t *testing.T) {
 	wdURL := "http://theinterwebs/asdf"
 	oaURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
 
-	configExpected := createAlertManagerConfig(pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1023,7 +1046,7 @@ func Test_createPagerdutySecret_Update(t *testing.T) {
 	var ret reconcile.Result
 	var err error
 
-	configExpected := createAlertManagerConfig(pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1194,7 +1217,7 @@ func Test_SecretReconciler(t *testing.T) {
 
 		// Create the secrets for this specific test.
 		if tt.amExists {
-			writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig("", "", "", "", "", defaultNamespaces))
+			writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig(reqLogger, "", "", "", "", "", defaultNamespaces))
 		}
 		if tt.dmsExists {
 			wdURL = "https://hjklasdf09876"
@@ -1211,7 +1234,7 @@ func Test_SecretReconciler(t *testing.T) {
 			oaURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
 			createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 		}
-		configExpected := createAlertManagerConfig(pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+		configExpected := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
 
 		verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1282,7 +1305,7 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 		createClusterVersion(reconciler)
 		createClusterProxy(reconciler)
 
-		writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig("", "", "", "", "", defaultNamespaces))
+		writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig(reqLogger, "", "", "", "", "", defaultNamespaces))
 
 		pdKey := "asdfjkl123"
 		dmsURL := "https://hjklasdf09876"
@@ -1306,7 +1329,7 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 		} else {
 			oaURL = ""
 		}
-		configExpected := createAlertManagerConfig(pdKey, dmsURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+		configExpected := createAlertManagerConfig(reqLogger, pdKey, dmsURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
 
 		verifyInhibitRules(t, configExpected.InhibitRules)
 


### PR DESCRIPTION
## What does this PR do?

- Alters the logic of the `secret` controller to only create a Dead Man's Snitch watchdog route/receiver if there is also a Pagerduty receiver needing to be configured.
- Includes some logging in the `createAlertManagerConfig` function, because more visibility into what the operator is doing is personally preferred.
- Reworks some of the test case helper functions to be position-independent when validating routes/receivers in the Alertmanager config.

## Why?

This was identified via incident [OHSS-17569](https://issues.redhat.com//browse/OHSS-17569) as an opportunity for improvement (and it was mistakenly believed the operator already behaved like this).

As PagerDuty and DMS are both required for monitoring, the lack of PagerDuty being configured on a cluster is an event that should rely on the other monitoring (in this case, DMS's watchdog) to raise an alarm to SRE that the cluster is "flying blind", as it were. By not configuring the watchdog, we trigger this behaviour.

## Jira

Refs [OSD-14346](https://issues.redhat.com//browse/OSD-14346)

## Docs

- The project `README` has been updated.
- The associated CHGM SOP will be updated to include a 'check PD/DMS in AlertManager config' section after merge of this PR.