### PR TITLE
adding GoAlert configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 ## Summary
 The Configure Alertmanager Operator was created for the OpenShift Dedicated platform to dynamically manage Alertmanager configurations based on the presence or absence of secrets containing a GoAlert URLs, Pager Duty RoutingKey, and [Dead Man's Snitch](https://deadmanssnitch.com) URL. When the secret is created/updated/deleted, the associated Receiver and Route will be created/updated/deleted within the Alertmanager config.
 
+The operator will only configure a Dead Man's Snitch watchdog receiver if a Pager Duty receiver is also configured to be present. This is in order to deliberately trigger a watchdog timeout if for some reason Pager Duty has not been configured, as both are required.  
+
 The operator contains the following components:
 
 * Secret controller: watches the `openshift-monitoring` namespace for any changes to relevant Secrets or ConfigMaps that are used in the configuration of Alertmanager. For more information on this see [Secret Controller](#secret-controller) below.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@
       - [Replace the Image](#replace-the-image)
 
 ## Summary
-The Configure Alertmanager Operator was created for the OpenShift Dedicated platform to dynamically manage Alertmanager configurations based on the presence or absence of secrets containing a Pager Duty RoutingKey and [Dead Man's Snitch](https://deadmanssnitch.com) URL. When the secret is created/updated/deleted, the associated Receiver and Route will be created/updated/deleted within the Alertmanager config.
-
-The operator will only configure a Dead Man's Snitch watchdog receiver if a Pager Duty receiver is also configured to be present. This is in order to deliberately trigger a watchdog timeout if for some reason Pager Duty has not been configured, as both are required.  
+The Configure Alertmanager Operator was created for the OpenShift Dedicated platform to dynamically manage Alertmanager configurations based on the presence or absence of secrets containing a GoAlert URLs, Pager Duty RoutingKey, and [Dead Man's Snitch](https://deadmanssnitch.com) URL. When the secret is created/updated/deleted, the associated Receiver and Route will be created/updated/deleted within the Alertmanager config.
 
 The operator contains the following components:
 
@@ -34,11 +32,12 @@ The Secret Controller watches over the resources in the table below. Changes to 
 | Resource Type | Resource Namespace/Name                   | Reason for watching                                                                                                                                    |
 |---------------|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Secret        | `openshift-monitoring/alertmanager-main`  | Represents the Alertmanager Configuration that the operator creates/maintains the state of.                                                            |
+| Secret        | `openshift-monitoring/goalert-secret`     | Indicates that the operator should configure GoAlert routing. Contains 3 values used by GoAlert; URL for high alerts, low alerts, and a heartbeat.              |
 | Secret        | `openshift-monitoring/pd-secret`          | Indicates that the operator should configure PagerDuty routing. Contains the PagerDuty API Key that is used for PagerDuty communications.              |
 | Secret        | `openshift-monitoring/dms-secret`         | Indicates that the operator should configure DeadmansSnitch routing. Contains the DeadmansSnitch URL that the Alertmanager should report readiness to. |
 | ConfigMap     | `openshift-monitoring/ocm-agent`          | Indicates that the operator should configure OCM Agent routing. Contains the OCM Agent service URL that Alertmanager should route alerts to.           |
-| ConfigMap     | `openshift-monitoring/managed-namespaces` | Defines a list of OpenShift "managed" namespaces. The operator will route alerts originating from these namespaces to PagerDuty.                       |
-| ConfigMap     | `openshift-monitoring/ocp-namespaces`     | Defines a list of OpenShift Container Platform namespaces. The operator will route alerts originating from these namespaces to PagerDuty.              |
+| ConfigMap     | `openshift-monitoring/managed-namespaces` | Defines a list of OpenShift "managed" namespaces. The operator will route alerts originating from these namespaces to PagerDuty and/or GoAlert.                       |
+| ConfigMap     | `openshift-monitoring/ocp-namespaces`     | Defines a list of OpenShift Container Platform namespaces. The operator will route alerts originating from these namespaces to PagerDuty and/or GoAlert.              |
 
 ## Cluster Readiness
 To avoid alert noise while a cluster is in the early stages of being installed and configured, this operator waits to configure Pager Duty -- effectively silencing alerts -- until a predetermined set of health checks, performed by [osd-cluster-ready](https://github.com/openshift/osd-cluster-ready/), has completed.
@@ -50,11 +49,13 @@ The Configure Alertmanager Operator exposes the following Prometheus metrics:
 
 | Metric name                           | Purpose                                                                                               |
 |---------------------------------------|-------------------------------------------------------------------------------------------------------|
+| `ga_secret_exists`                    | indicates that a Secret named `goalert-secret` exists in the `openshift-monitoring` namespace.        |
 | `pd_secret_exists`                    | indicates that a Secret named `pd-secret` exists in the `openshift-monitoring` namespace.             |
 | `dms_secret_exists`                   | indicates that a Secret named `dms-secret` exists in the `openshift-monitoring` namespace.            |
 | `am_secret_exists`                    | indicates that a Secret named `alertmanager-main` exists in the `openshift-monitoring` namespace.     |
 | `managed_namespaces_configmap_exists` | indicates that a ConfigMap named `managed-namespaces` exists in the `openshift-monitoring` namespace. |
 | `ocp_namespaces_configmap_exists`     | indicates that a ConfigMap named `ocp-namespaces` exists in the `openshift-monitoring` namespace.     |
+| `am_secret_contains_ga`               | indicates the GoAlert receiver is present in alertmanager.yaml.                                       |
 | `am_secret_contains_pd`               | indicates the Pager Duty receiver is present in alertmanager.yaml.                                    |
 | `am_secret_contains_dms`              | indicates the Dead Man's Snitch receiver is present in alertmanager.yaml.                             |
 
@@ -63,6 +64,7 @@ The operator creates a `Service` and `ServiceMonitor` named `configure-alertmana
 ## Alerts
 The following alerts are added to Prometheus as part of configure-alertmanager-operator:
 * Mismatch between DMS secret and DMS Alertmanager config.
+* Mismatch between GoAlert secret and GoAlert Alertmanager config.
 * Mismatch between PD secret and PD Alertmanager config.
 * Alertmanager config secret does not exist.
 

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -45,7 +45,7 @@ var log = logf.Log.WithName("secret_controller")
 type receiverType int64
 
 const (
-	// Defining reciever types to be used in subroute decision making
+	// Defining receiver types to be used in subroute decision making
 	GoAlert receiverType = iota
 	Pagerduty
 

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -384,7 +384,7 @@ func createSubroutes(reqLogger logr.Logger, namespaceList []string, receiverType
 		// https://issues.redhat.com/browse/OSD-14857
 		{Receiver: receiverNull, MatchRE: map[string]string{"mountpoint": "/var/lib/ibmc-s3fs.*"}, Match: map[string]string{"alertname": "NodeFilesystemAlmostOutOfSpace", "severity": "critical"}},
 		// Needed because we are now allowing DMS to continue to allow DMS and GoAlert Heartbeat to coexist. Now we just drop DMS.
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "SnitchHeartBeat", "severity": "deadman"}},
+		// {Receiver: receiverNull, Match: map[string]string{"alertname": "SnitchHeartBeat", "severity": "deadman"}},
 		// Needed to drop GoAlert heartbeat alerts
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "Watchdog", "severity": "none"}},
 		// https://issues.redhat.com/browse/OSD-1922

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -253,11 +253,7 @@ func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func createSubroutes(namespaceList []string, receiverType string) *alertmanager.Route {
 
-	receiverCommon := ""
-	receiverCritical := ""
-	receiverError := ""
-	receiverWarning := ""
-	receiverDefault := ""
+	var receiverCommon,	receiverCritical, receiverError, receiverWarning, receiverDefault string
 
 	if receiverType == "goalert" {
 		receiverCommon = receiverGoAlertLow
@@ -348,7 +344,6 @@ func createSubroutes(namespaceList []string, receiverType string) *alertmanager.
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ElasticsearchOperatorCSVNotSuccessful", "namespace": "openshift-logging"}}, // this has happened last week
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ElasticsearchProcessCPUHigh", "namespace": "openshift-logging"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ElasticsearchWriteRequestsRejectionJumps", "namespace": "openshift-logging"}},
-		// END of https://issues.redhat.com/browse/OSD-11273
 		// Suppress the alerts and use HAProxyReloadFailSRE instead (openshift/managed-cluster-config#600)
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "HAProxyReloadFail", "severity": "critical"}},
 		// https://issues.redhat.com/browse/OHSS-2163

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -251,7 +251,7 @@ func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func createSubroutes(reqLogger logr.Logger, namespaceList []string, receiverType string) *alertmanager.Route{
+func createSubroutes(reqLogger logr.Logger, namespaceList []string, receiverType string) *alertmanager.Route {
 
 	var receiverCommon, receiverCritical, receiverError, receiverWarning, receiverDefault string
 
@@ -680,7 +680,7 @@ func createAlertManagerConfig(reqLogger logr.Logger, pagerdutyRoutingKey, goaler
 		routes = append(routes, createSubroutes(reqLogger, namespaceList, "pagerduty"))
 		receivers = append(receivers, createPagerdutyReceivers(pagerdutyRoutingKey, clusterID, clusterProxy)...)
 	} else {
-	reqLogger.Info("INFO: Not configuring PagerDuty or Dead Man's Snitch receivers")
+		reqLogger.Info("INFO: Not configuring PagerDuty or Dead Man's Snitch receivers")
 	}
 
 	if goalertURLlow != "" && goalertURLhigh != "" {
@@ -913,11 +913,7 @@ func (r *SecretReconciler) parseSecrets(reqLogger logr.Logger, secretList *corev
 	snitchSecretExists := secretInList(reqLogger, secretNameDMS, secretList)
 
 	// do the work! collect secret info for PD, DMS, and GoAlert
-	goalertURLlow = ""
-	goalertURLhigh = ""
-	goalertURLheartbeat = ""
-	pagerdutyRoutingKey = ""
-	watchdogURL = ""
+	goalertURLlow, goalertURLhigh, goalertURLheartbeat, pagerdutyRoutingKey, watchdogURL = "", "", "", "", ""
 
 	// If a secret exists, add the necessary configs to Alertmanager.
 	// But don't activate PagerDuty/Goalert unless the cluster is "ready".

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -283,7 +283,10 @@ func createSubroutes(reqLogger logr.Logger, namespaceList []string, receiverType
 	//
 	// the Route docs can be read at https://prometheus.io/docs/alerting/latest/configuration/#matcher
 	subroute := []*alertmanager.Route{
-
+		// Needed because we are now allowing DMS to continue to allow DMS and GoAlert Heartbeat to coexist. Now we just drop DMS.
+		// {Receiver: receiverNull, Match: map[string]string{"alertname": "SnitchHeartBeat", "severity": "deadman"}},
+		// Needed to drop GoAlert heartbeat alerts
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "Watchdog", "severity": "none"}},
 		// https://issues.redhat.com/browse/OSD-11298
 		// indications that master nodes have been terminated should be critical
 		// regex tests: https://regex101.com/r/Rn6F5A/1
@@ -383,10 +386,6 @@ func createSubroutes(reqLogger logr.Logger, namespaceList []string, receiverType
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "MultipleDefaultStorageClasses", "namespace": "openshift-cluster-storage-operator"}},
 		// https://issues.redhat.com/browse/OSD-14857
 		{Receiver: receiverNull, MatchRE: map[string]string{"mountpoint": "/var/lib/ibmc-s3fs.*"}, Match: map[string]string{"alertname": "NodeFilesystemAlmostOutOfSpace", "severity": "critical"}},
-		// Needed because we are now allowing DMS to continue to allow DMS and GoAlert Heartbeat to coexist. Now we just drop DMS.
-		// {Receiver: receiverNull, Match: map[string]string{"alertname": "SnitchHeartBeat", "severity": "deadman"}},
-		// Needed to drop GoAlert heartbeat alerts
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "Watchdog", "severity": "none"}},
 		// https://issues.redhat.com/browse/OSD-1922
 		{Receiver: receiverWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},
 		// https://issues.redhat.com/browse/OSD-8983

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -289,7 +289,6 @@ func createSubroutes(namespaceList []string, receiverType string) *alertmanager.
 		// regex tests: https://regex101.com/r/Rn6F5A/1
 		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-[123]$"}, Match: map[string]string{"alertname": "MachineWithoutValidNode", "namespace": "openshift-machine-api"}},
 		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-[123]$"}, Match: map[string]string{"alertname": "MachineWithNoRunningPhase", "namespace": "openshift-machine-api"}},
-
 		// Silence anything intended for OCM Agent
 		// https://issues.redhat.com/browse/SDE-1315
 		{Receiver: receiverNull, Match: map[string]string{managedNotificationLabel: "true"}},
@@ -333,15 +332,6 @@ func createSubroutes(namespaceList []string, receiverType string) *alertmanager.
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "TargetDown"}},
 		// https://issues.redhat.com/browse/OSD-5544
 		{Receiver: receiverNull, MatchRE: map[string]string{"job_name": "^elasticsearch.*"}, Match: map[string]string{"alertname": "KubeJobFailed", "namespace": "openshift-logging"}},
-		// https://issues.redhat.com/browse/OSD-11273 - silence all elasticsearch alerts so we can handle only the ones that have extended logging support
-		// the list of alerts is pulled via
-		// ```
-		//  yq '.spec.groups[].rules[].alert | select( . != null) ' ../managed-cluster-config/resources/prometheusrules/fluentd_openshift-logging_collector.PrometheusRule.yaml | sort -u | awk '{print "{Receiver: receiverNull, Match: map[string]string{\"alertname\": \"" $1 "\", \"namespace\": \"openshift-logging\"}},"}'
-		// # for elasticsearch
-		// yq '.spec.groups[].rules[].alert | select( . != null) ' ../managed-cluster-config/resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml | sort -u | awk '{print "{Receiver: receiverNull, Match: map[string]string{\"alertname\": \"" $1 "\", \"namespace\": \"openshift-logging\"}},"}'
-		// ```
-		// pass all of the alerts that are SRE related to PD
-		{Receiver: receiverCommon, MatchRE: map[string]string{"alertname": "^.*SRE$"}, Match: map[string]string{"namespace": "openshift-logging"}},
 		// fluentd alerts
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentDHighErrorRate", "namespace": "openshift-logging"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentDVeryHighErrorRate", "namespace": "openshift-logging"}},
@@ -367,83 +357,70 @@ func createSubroutes(namespaceList []string, receiverType string) *alertmanager.
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication", "reason": "IdentityProviderConfig_Error"}},
 		// https://issues.redhat.com/browse/OSD-6363
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDegraded", "name": "authentication", "reason": "OAuthServerConfigObservation_Error"}},
-
 		//https://issues.redhat.com/browse/OSD-8320
 		// Sometimes only CLusterOperatorDown is firing, meaning the suppression set below in this file does not work
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "IdentityProviderConfig_Error"}},
 		//https://issues.redhat.com/browse/OSD-8320
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "OAuthServerConfigObservation_Error"}},
-
 		// https://issues.redhat.com/browse/OSD-6327
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CannotRetrieveUpdates"}},
-
 		//https://issues.redhat.com/browse/OSD-6559
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusNotIngestingSamples", "namespace": "openshift-user-workload-monitoring"}},
-
 		//https://issues.redhat.com/browse/OSD-7671
 		// might also be removed by https://issues.redhat.com/browse/OSD-11273
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentdQueueLengthBurst", "namespace": "openshift-logging", "severity": "warning"}},
-
 		// https://issues.redhat.com/browse/OSD-9061
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterAutoscalerUnschedulablePods", "namespace": "openshift-machine-api"}},
-
 		// https://issues.redhat.com/browse/OSD-9062
 		{Receiver: receiverNull, Match: map[string]string{"severity": "alert"}},
-
+		// https://issues.redhat.com/browse/OSD-6821
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusBadConfig", "namespace": "openshift-user-workload-monitoring"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusDuplicateTimestamps", "namespace": "openshift-user-workload-monitoring"}},
+		// https://issues.redhat.com/browse/OSD-9426
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusTargetSyncFailure", "namespace": "openshift-user-workload-monitoring"}},
+		// https://issues.redhat.com/browse/OSD-11478
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusOperatorRejectedResources", "namespace": "openshift-user-workload-monitoring"}},
+		// https://issues.redhat.com/browse/OSD-14071
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "MultipleDefaultStorageClasses", "namespace": "openshift-cluster-storage-operator"}},
+		// https://issues.redhat.com/browse/OSD-14857
+		{Receiver: receiverNull, MatchRE: map[string]string{"mountpoint": "/var/lib/ibmc-s3fs.*"}, Match: map[string]string{"alertname": "NodeFilesystemAlmostOutOfSpace", "severity": "critical"}},
+		// Needed because we are now allowing DMS to continue to allow DMS and GoAlert Heartbeat to coexist. Now we just drop DMS.
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "SnitchHeartBeat", "severity": "deadman"}},
+		// Needed to drop GoAlert heartbeat alerts
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "Watchdog", "severity": "none"}},
 		// https://issues.redhat.com/browse/OSD-1922
 		{Receiver: receiverWarning, Match: map[string]string{"alertname": "KubeAPILatencyHigh", "severity": "critical"}},
-
+		// https://issues.redhat.com/browse/OSD-8983
+		{Receiver: receiverWarning, Match: map[string]string{"alertname": "etcdGRPCRequestsSlow", "namespace": "openshift-etcd"}},
+		// https://issues.redhat.com/browse/OSD-10473
+		{Receiver: receiverWarning, Match: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU", "namespace": "openshift-kube-apiserver"}},
+		// https://issues.redhat.com/browse/OSD-10485
+		{Receiver: receiverWarning, Match: map[string]string{"alertname": "etcdHighNumberOfFailedGRPCRequests", "namespace": "openshift-etcd"}},
+		// https://issues.redhat.com/browse/DVO-54
+		{Receiver: receiverWarning, Match: map[string]string{"severity": "critical", "namespace": "openshift-deployment-validation-operator"}},
+		// Ensure NodeClockNotSynchronising is routed to PD as a high alert
+		// https://issues.redhat.com/browse/OSD-8736
+		{Receiver: receiverError, Match: map[string]string{"alertname": "NodeClockNotSynchronising", "prometheus": "openshift-monitoring/k8s"}},
+		// https://issues.redhat.com/browse/OSD-11273 - silence all elasticsearch alerts so we can handle only the ones that have extended logging support
+		// the list of alerts is pulled via
+		// ```
+		//  yq '.spec.groups[].rules[].alert | select( . != null) ' ../managed-cluster-config/resources/prometheusrules/fluentd_openshift-logging_collector.PrometheusRule.yaml | sort -u | awk '{print "{Receiver: receiverNull, Match: map[string]string{\"alertname\": \"" $1 "\", \"namespace\": \"openshift-logging\"}},"}'
+		// # for elasticsearch
+		// yq '.spec.groups[].rules[].alert | select( . != null) ' ../managed-cluster-config/resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml | sort -u | awk '{print "{Receiver: receiverNull, Match: map[string]string{\"alertname\": \"" $1 "\", \"namespace\": \"openshift-logging\"}},"}'
+		// ```
+		// pass all of the alerts that are SRE related to PD
+		{Receiver: receiverCommon, MatchRE: map[string]string{"alertname": "^.*SRE$"}, Match: map[string]string{"namespace": "openshift-logging"}},
 		// fluentd: route any fluentd alert to PD
 		// https://issues.redhat.com/browse/OSD-3326
 		{Receiver: receiverCommon, Match: map[string]string{"job": "fluentd", "prometheus": "openshift-monitoring/k8s"}},
 		// elasticsearch: route any ES alert to PD
 		// https://issues.redhat.com/browse/OSD-3326
 		{Receiver: receiverCommon, Match: map[string]string{"cluster": "elasticsearch", "prometheus": "openshift-monitoring/k8s"}},
-
-		//Add any alerts below to override their severity to Error
-
-		// Ensure NodeClockNotSynchronising is routed to PD as a high alert
-		// https://issues.redhat.com/browse/OSD-8736
-		{Receiver: receiverError, Match: map[string]string{"alertname": "NodeClockNotSynchronising", "prometheus": "openshift-monitoring/k8s"}},
-
 		// Route KubeAPIErrorBudgetBurn to PD despite lack of namespace label
 		// https://issues.redhat.com/browse/OSD-8006
 		{Receiver: receiverCommon, Match: map[string]string{"alertname": "KubeAPIErrorBudgetBurn", "prometheus": "openshift-monitoring/k8s"}},
-
-		// https://issues.redhat.com/browse/OSD-6821
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusBadConfig", "namespace": "openshift-user-workload-monitoring"}},
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusDuplicateTimestamps", "namespace": "openshift-user-workload-monitoring"}},
-
-		// https://issues.redhat.com/browse/OSD-9426
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusTargetSyncFailure", "namespace": "openshift-user-workload-monitoring"}},
-
-		// https://issues.redhat.com/browse/OSD-11478
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusOperatorRejectedResources", "namespace": "openshift-user-workload-monitoring"}},
-
-		// https://issues.redhat.com/browse/OSD-8983
-		{Receiver: receiverWarning, Match: map[string]string{"alertname": "etcdGRPCRequestsSlow", "namespace": "openshift-etcd"}},
-
-		// https://issues.redhat.com/browse/OSD-10473
-		{Receiver: receiverWarning, Match: map[string]string{"alertname": "ExtremelyHighIndividualControlPlaneCPU", "namespace": "openshift-kube-apiserver"}},
-
-		// https://issues.redhat.com/browse/OSD-10485
-		{Receiver: receiverWarning, Match: map[string]string{"alertname": "etcdHighNumberOfFailedGRPCRequests", "namespace": "openshift-etcd"}},
-
-		// https://issues.redhat.com/browse/DVO-54
-		{Receiver: receiverWarning, Match: map[string]string{"severity": "critical", "namespace": "openshift-deployment-validation-operator"}},
-
-		// https://issues.redhat.com/browse/OSD-14071
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "MultipleDefaultStorageClasses", "namespace": "openshift-cluster-storage-operator"}},
-
-		// https://issues.redhat.com/browse/OSD-14857
-		{Receiver: receiverNull, MatchRE: map[string]string{"mountpoint": "/var/lib/ibmc-s3fs.*"}, Match: map[string]string{"alertname": "NodeFilesystemAlmostOutOfSpace", "severity": "critical"}},
-
-		// Needed because we are now allowing DMS to continue to allow DMS and GoAlert Heartbeat to coexist. Now we just drop DMS.
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "SnitchHeartBeat", "severity": "deadman"}},
-
-		// Needed to drop GoAlert heartbeat alerts
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "Watchdog", "severity": "none"}},
 	}
+
 	// Silence insights in FedRAMP until its made available in the environment
 	// https://issues.redhat.com/browse/OSD-13685
 	if config.IsFedramp() {

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -459,7 +459,6 @@ func createSubroutes(namespaceList []string, receiverType string) *alertmanager.
 			{Receiver: receiverCritical, Match: map[string]string{"severity": "critical"}},
 			{Receiver: receiverError, Match: map[string]string{"severity": "error"}},
 			{Receiver: receiverWarning, Match: map[string]string{"severity": "warning"}},
-			{Receiver: receiverWarning, Match: map[string]string{"severity": "info"}},
 		}...)
 	}
 

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -452,6 +452,17 @@ func createSubroutes(namespaceList []string, receiverType string) *alertmanager.
 		)
 	}
 
+	// GoAlert specific settings
+	if receiverType == "goalert" {
+		// Overcome webhook limitations
+		subroute = append(subroute, []*alertmanager.Route{
+			{Receiver: receiverCritical, Match: map[string]string{"severity": "critical"}},
+			{Receiver: receiverError, Match: map[string]string{"severity": "error"}},
+			{Receiver: receiverWarning, Match: map[string]string{"severity": "warning"}},
+			{Receiver: receiverWarning, Match: map[string]string{"severity": "info"}},
+		}...)
+	}
+
 	for _, namespace := range namespaceList {
 		subroute = append(subroute, []*alertmanager.Route{
 			// https://issues.redhat.com/browse/OSD-3086

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -666,25 +666,21 @@ func createAlertManagerConfig(reqLogger logr.Logger, pagerdutyRoutingKey, goaler
 	routes := []*alertmanager.Route{}
 	receivers := []*alertmanager.Receiver{}
 
+	if watchdogURL != "" {
+    reqLogger.Info("INFO: Configuring a watchdog route and receiver")
+		routes = append(routes, createWatchdogRoute())
+		receivers = append(receivers, createWatchdogReceivers(watchdogURL, clusterProxy)...)
+	}
+
 	if ocmAgentURL != "" {
-		reqLogger.Info("INFO: Configuring a OCM Agent route and receiver")
 		routes = append(routes, createOCMAgentRoute())
 		receivers = append(receivers, createOCMAgentReceiver(ocmAgentURL)...)
 	}
 
 	if pagerdutyRoutingKey != "" {
-		if watchdogURL != "" {
-			// Only configure a watchdog route if we know that a Pagerduty route is
-			// also being configured (OSD-14347)
-			reqLogger.Info("INFO: Configuring a watchdog route and receiver")
-			routes = append(routes, createWatchdogRoute())
-			receivers = append(receivers, createWatchdogReceivers(watchdogURL, clusterProxy)...)
-		}
 		reqLogger.Info("INFO: Configuring a PagerDuty route and receiver")
 		routes = append(routes, createSubroutes(namespaceList, Pagerduty))
 		receivers = append(receivers, createPagerdutyReceivers(pagerdutyRoutingKey, clusterID, clusterProxy)...)
-	} else {
-		reqLogger.Info("INFO: Not configuring PagerDuty or Dead Man's Snitch receivers")
 	}
 
 	if goalertURLlow != "" && goalertURLhigh != "" {

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -942,14 +942,14 @@ func Test_readOCMAgentServiceURLFromConfig(t *testing.T) {
 
 func Test_createPagerdutyRoute(t *testing.T) {
 	// test the structure of the Route is sane
-	route := createSubroutes(defaultNamespaces, "pagerduty")
+	route := createSubroutes(reqLogger, defaultNamespaces, "pagerduty")
 
 	verifyPagerdutyRoute(t, route, defaultNamespaces)
 }
 
 func Test_createGoalertSubroute(t *testing.T) {
 	// test the structure of the Route is sane
-	route := createSubroutes(defaultNamespaces, "goalert")
+	route := createSubroutes(reqLogger, defaultNamespaces, "goalert")
 
 	verifyGoalertRoute(t, route, defaultNamespaces)
 }

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -158,6 +158,37 @@ func verifyPagerdutyRoute(t *testing.T, route *alertmanager.Route, expectedNames
 	assertTrue(t, hasFluentd, "No route for Match on job=fluentd")
 }
 
+// utility class to test Goalert route creation
+func verifyGoalertRoute(t *testing.T, route *alertmanager.Route, expectedNamespaces []string) {
+	assertEquals(t, receiverGoAlertLow, route.Receiver, "Receiver Name")
+	assertEquals(t, true, route.Continue, "Continue")
+	assertEquals(t, []string{"alertname", "severity"}, route.GroupByStr, "GroupByStr")
+	assertGte(t, 1, len(route.Routes), "Number of Routes")
+
+	// verify we have the core routes for namespace, ES, and fluentd
+	hasNamespace := false
+	hasElasticsearch := false
+	hasFluentd := false
+	routeNamespaces := []string{}
+	for _, route := range route.Routes {
+		if route.Receiver == receiverGoAlertLow && route.MatchRE["namespace"] != "" {
+			routeNamespaces = append(routeNamespaces, route.MatchRE["namespace"])
+		} else if route.Match["job"] == "fluentd" {
+			hasFluentd = true
+		} else if route.Match["cluster"] == "elasticsearch" {
+			hasElasticsearch = true
+		}
+	}
+
+	if reflect.DeepEqual(expectedNamespaces, routeNamespaces) {
+		hasNamespace = true
+	}
+
+	assertTrue(t, hasNamespace, "No route for MatchRE on namespace")
+	assertTrue(t, hasElasticsearch, "No route for Match on cluster=elasticsearch")
+	assertTrue(t, hasFluentd, "No route for Match on job=fluentd")
+}
+
 func verifyNullReceiver(t *testing.T, receivers []*alertmanager.Receiver) {
 	hasNull := false
 	for _, receiver := range receivers {
@@ -214,6 +245,69 @@ func verifyPagerdutyReceivers(t *testing.T, key string, proxy string, receivers 
 	assertTrue(t, hasMakeItError, fmt.Sprintf("No '%s' receiver", receiverMakeItError))
 	assertTrue(t, hasMakeItWarning, fmt.Sprintf("No '%s' receiver", receiverMakeItWarning))
 	assertTrue(t, hasPagerduty, fmt.Sprintf("No '%s' receiver", receiverPagerduty))
+}
+
+// utility function to verify Goalert Receivers
+func verifyGoalertLowReceivers(t *testing.T, url string, proxy string, receivers []*alertmanager.Receiver) {
+	// there are at least 1 receiver: goalert
+	assertGte(t, 1, len(receivers), "Number of Receivers")
+
+	hasGoalertLow := false
+
+	for _, receiver := range receivers {
+		if receiver.Name == receiverGoAlertLow {
+			hasGoalertLow = true
+			assertEquals(t, true, receiver.WebhookConfigs[0].NotifierConfig.VSendResolved, "VSendResolved")
+			assertEquals(t, url, receiver.WebhookConfigs[0].URL, "URL")
+			assertEquals(t, proxy, receiver.WebhookConfigs[0].HttpConfig.ProxyURL, "Proxy")
+		}
+	}
+	assertTrue(t, hasGoalertLow, fmt.Sprintf("No '%s' receiver", receiverGoAlertLow))
+}
+
+// utility function to verify Goalert Receivers
+func verifyGoalertHighReceivers(t *testing.T, url string, proxy string, receivers []*alertmanager.Receiver) {
+	// there are at least 1 receivers: goalert-high
+	assertGte(t, 1, len(receivers), "Number of Receivers")
+
+	hasGoalertHigh := false
+
+	for _, receiver := range receivers {
+		if receiver.Name == receiverGoAlertHigh {
+			hasGoalertHigh = true
+			assertEquals(t, true, receiver.WebhookConfigs[0].NotifierConfig.VSendResolved, "VSendResolved")
+			assertEquals(t, url, receiver.WebhookConfigs[0].URL, "URL")
+			assertEquals(t, proxy, receiver.WebhookConfigs[0].HttpConfig.ProxyURL, "Proxy")
+		}
+	}
+	assertTrue(t, hasGoalertHigh, fmt.Sprintf("No '%s' receiver", receiverGoAlertHigh))
+}
+
+// utility function to verify Goalert Heartbeat
+func verifyHeartbeatRoute(t *testing.T, route *alertmanager.Route) {
+	assertEquals(t, receiverGoAlertHeartbeat, route.Receiver, "Receiver Name")
+	assertEquals(t, "5m", route.RepeatInterval, "Repeat Interval")
+	assertEquals(t, "Watchdog", route.Match["alertname"], "Alert Name")
+	assertEquals(t, true, route.Continue, "Continue")
+}
+
+// utility to test Goalert heartbeat receivers
+func verifyHeartbeatReceiver(t *testing.T, url string, proxy string, receivers []*alertmanager.Receiver) {
+	// there is at least 1 receiver
+	assertGte(t, 1, len(receivers), "Number of Receivers")
+
+	// verify structure of each
+	hasWatchdog := false
+	for _, receiver := range receivers {
+		if receiver.Name == receiverGoAlertHeartbeat {
+			hasWatchdog = true
+			assertTrue(t, receiver.WebhookConfigs[0].VSendResolved, "VSendResolved")
+			assertEquals(t, url, receiver.WebhookConfigs[0].URL, "URL")
+			assertEquals(t, proxy, receiver.WebhookConfigs[0].HttpConfig.ProxyURL, "Proxy")
+		}
+	}
+
+	assertTrue(t, hasWatchdog, fmt.Sprintf("No '%s' receiver", receiverWatchdog))
 }
 
 // utility function to verify no watchdog routes appear in the routes
@@ -485,6 +579,7 @@ func Test_secretInList(t *testing.T) {
 	createNamespace(reconciler, t)
 	createSecret(reconciler, secretNamePD, secretKeyPD, "")
 	createSecret(reconciler, secretNameDMS, secretKeyDMS, "")
+	createGoAlertSecret(reconciler, secretNameGoalert, secretKeyGoalertLow, secretKeyGoalertHigh, secretKeyGoalertHeartbeat, "", "", "")
 
 	secretList := corev1.SecretList{}
 	err := reconciler.Client.List(context.TODO(), &secretList, &client.ListOptions{})
@@ -494,6 +589,7 @@ func Test_secretInList(t *testing.T) {
 
 	assertTrue(t, secretInList(reqLogger, secretNamePD, &secretList), fmt.Sprintf("Expected Secret to be present in list: %s", secretNamePD))
 	assertTrue(t, secretInList(reqLogger, secretNameDMS, &secretList), fmt.Sprintf("Expected Secret to be present in list: %s", secretNameDMS))
+	assertTrue(t, secretInList(reqLogger, secretNameGoalert, &secretList), fmt.Sprintf("Expected Secret to be present in list: %s", secretNameGoalert))
 	assertTrue(t, !secretInList(reqLogger, "fake-secret", &secretList), fmt.Sprintf("Did not expect Secret to be present in list: %s", "fake-secret"))
 }
 
@@ -507,10 +603,21 @@ func Test_parseSecrets(t *testing.T) {
 
 	pdKey := "asdfjkl123"
 	dmsURL := "https://hjklasdf09876"
+	gaHighURL := "https://dummy-gahigh-url"
+	gaLowURL := "https://dummy-galow-url"
+	gaHeartURL := "https://dummy-gaheartbeat-url"
 
 	createNamespace(reconciler, t)
 	createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
 	createSecret(reconciler, secretNameDMS, secretKeyDMS, dmsURL)
+	createGoAlertSecret(reconciler,
+		secretNameGoalert,
+		secretKeyGoalertLow,
+		secretKeyGoalertHigh,
+		secretKeyGoalertHeartbeat,
+		gaLowURL,
+		gaHighURL,
+		gaHeartURL)
 
 	secretList := &corev1.SecretList{}
 	err := reconciler.Client.List(context.TODO(), secretList, &client.ListOptions{})
@@ -519,10 +626,13 @@ func Test_parseSecrets(t *testing.T) {
 	}
 
 	request := createReconcileRequest(reconciler, secretNamePD)
-	pagerdutyRoutingKey, watchdogURL := reconciler.parseSecrets(reqLogger, secretList, request.Namespace, true)
+	pagerdutyRoutingKey, watchdogURL, goalertURLlow, goalertURLhigh, goalertURLheartbeat := reconciler.parseSecrets(reqLogger, secretList, request.Namespace, true)
 
 	assertEquals(t, pdKey, pagerdutyRoutingKey, "Expected PagerDuty routing keys to match")
 	assertEquals(t, dmsURL, watchdogURL, "Expected DMS URLs to match")
+	assertEquals(t, gaLowURL, goalertURLlow, "Expected GoAlert Low URLs to match")
+	assertEquals(t, gaHighURL, goalertURLhigh, "Expected GoAlert High URLs to match")
+	assertEquals(t, gaHeartURL, goalertURLheartbeat, "Expected GoAlert Heartbeat URLs to match")
 }
 
 // Test_parseSecrets tests the parseSecrets function when the DMS secret does not exist
@@ -545,10 +655,13 @@ func Test_parseSecrets_MissingDMS(t *testing.T) {
 	}
 
 	request := createReconcileRequest(reconciler, secretNamePD)
-	pagerdutyRoutingKey, watchdogURL := reconciler.parseSecrets(reqLogger, secretList, request.Namespace, true)
+	pagerdutyRoutingKey, watchdogURL, goalertURLlow, goalertURLhigh, goalertURLheartbeat := reconciler.parseSecrets(reqLogger, secretList, request.Namespace, true)
 
 	assertEquals(t, pdKey, pagerdutyRoutingKey, "Expected PagerDuty routing keys to match")
 	assertEquals(t, "", watchdogURL, "Expected DMS URLs to match")
+	assertEquals(t, "", goalertURLlow, "Expected GoAlert Low URLs to match")
+	assertEquals(t, "", goalertURLhigh, "Expected GoAlert High URLs to match")
+	assertEquals(t, "", goalertURLheartbeat, "Expected GoAlert Heartbeat URLs to match")
 }
 
 // Tests the parseSecrets function when the PD secret does not exist
@@ -571,10 +684,51 @@ func Test_parseSecrets_MissingPagerDuty(t *testing.T) {
 	}
 
 	request := createReconcileRequest(reconciler, secretNamePD)
-	pagerdutyRoutingKey, watchdogURL := reconciler.parseSecrets(reqLogger, secretList, request.Namespace, true)
+	pagerdutyRoutingKey, watchdogURL, goalertURLlow, goalertURLhigh, goalertURLheartbeat := reconciler.parseSecrets(reqLogger, secretList, request.Namespace, true)
 
 	assertEquals(t, "", pagerdutyRoutingKey, "Expected PagerDuty routing keys to match")
 	assertEquals(t, dmsURL, watchdogURL, "Expected DMS URLs to match")
+	assertEquals(t, "", goalertURLlow, "Expected GoAlert Low URLs to match")
+	assertEquals(t, "", goalertURLhigh, "Expected GoAlert High URLs to match")
+	assertEquals(t, "", goalertURLheartbeat, "Expected GoAlert Heartbeat URLs to match")
+}
+
+// Tests the parseSecrets function when the GoAlert secrets do not exist
+func Test_parseSecrets_MissingGoAlert(t *testing.T) {
+	// prepare environment
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockReadiness := readiness.NewMockInterface(ctrl)
+	reconciler := createReconciler(t, mockReadiness)
+
+	gaHighURL := "https://dummy-gahigh-url"
+	gaLowURL := "https://dummy-galow-url"
+	gaHeartURL := "https://dummy-gaheartbeat-url"
+
+	createNamespace(reconciler, t)
+	createGoAlertSecret(reconciler,
+		secretNameGoalert,
+		secretKeyGoalertLow,
+		secretKeyGoalertHigh,
+		secretKeyGoalertHeartbeat,
+		gaLowURL,
+		gaHighURL,
+		gaHeartURL)
+
+	secretList := &corev1.SecretList{}
+	err := reconciler.Client.List(context.TODO(), secretList, &client.ListOptions{})
+	if err != nil {
+		t.Fatalf("Could not list Secrets: %v", err)
+	}
+
+	request := createReconcileRequest(reconciler, secretNameGoalert)
+	pagerdutyRoutingKey, watchdogURL, goalertURLlow, goalertURLhigh, goalertURLheartbeat := reconciler.parseSecrets(reqLogger, secretList, request.Namespace, true)
+
+	assertEquals(t, "", pagerdutyRoutingKey, "Expected PagerDuty routing keys to match")
+	assertEquals(t, "", watchdogURL, "Expected DMS URLs to match")
+	assertEquals(t, gaLowURL, goalertURLlow, "Expected GoAlert Low URLs to match")
+	assertEquals(t, gaHighURL, goalertURLhigh, "Expected GoAlert High URLs to match")
+	assertEquals(t, gaHeartURL, goalertURLheartbeat, "Expected GoAlert Heartbeat URLs to match")
 }
 
 // Test_parseConfigMaps tests the parseConfigMaps function under various circumstances
@@ -788,13 +942,24 @@ func Test_readOCMAgentServiceURLFromConfig(t *testing.T) {
 
 func Test_createPagerdutyRoute(t *testing.T) {
 	// test the structure of the Route is sane
-	route := createPagerdutyRoute(defaultNamespaces)
+	route := createSubroutes(defaultNamespaces, "pagerduty")
 
 	verifyPagerdutyRoute(t, route, defaultNamespaces)
 }
 
+func Test_createGoalertSubroute(t *testing.T) {
+	// test the structure of the Route is sane
+	route := createSubroutes(defaultNamespaces, "goalert")
+
+	verifyGoalertRoute(t, route, defaultNamespaces)
+}
+
 func Test_createPagerdutyReceivers_WithoutKey(t *testing.T) {
 	assertEquals(t, 0, len(createPagerdutyReceivers("", "", "")), "Number of Receivers")
+}
+
+func Test_createGoalertReceivers_WithoutURL(t *testing.T) {
+	assertEquals(t, 0, len(createGoalertReceiver("", "", "")), "Number of Receivers")
 }
 
 func Test_createPagerdutyReceivers_WithKey(t *testing.T) {
@@ -803,6 +968,15 @@ func Test_createPagerdutyReceivers_WithKey(t *testing.T) {
 	receivers := createPagerdutyReceivers(key, exampleClusterId, exampleProxy)
 
 	verifyPagerdutyReceivers(t, key, exampleProxy, receivers)
+}
+
+func Test_createGoalertReceivers_WithURL(t *testing.T) {
+	url := "https://dummy-ga-url"
+
+	receiver := createGoalertReceiver(url, receiverGoAlertLow, exampleProxy)
+	verifyGoalertLowReceivers(t, url, exampleProxy, receiver)
+	receiver = createGoalertReceiver(url, receiverGoAlertHigh, exampleProxy)
+	verifyGoalertHighReceivers(t, url, exampleProxy, receiver)
 }
 
 func Test_createWatchdogRoute(t *testing.T) {
@@ -824,12 +998,34 @@ func Test_createWatchdogReceivers_WithKey(t *testing.T) {
 	verifyWatchdogReceiver(t, url, exampleProxy, true, receivers)
 }
 
+func Test_createHeartbeatRoute(t *testing.T) {
+	// test the structure of the Route is sane
+	route := createHeartbeatRoute()
+
+	verifyHeartbeatRoute(t, route)
+}
+
+func Test_createHeartbeatReceivers_WithoutURL(t *testing.T) {
+	assertEquals(t, 0, len(createHeartbeatReceivers("", "")), "Number of Receivers")
+}
+
+func Test_createHeartbeatReceivers_WithKey(t *testing.T) {
+	url := "https://whatever/something"
+
+	receivers := createHeartbeatReceivers(url, exampleProxy)
+
+	verifyHeartbeatReceiver(t, url, exampleProxy, receivers)
+}
+
 func Test_createAlertManagerConfig_WithoutKey_WithoutURL(t *testing.T) {
 	pdKey := ""
 	wdURL := ""
 	oaURL := ""
+	gaHighURL := ""
+	gaLowURL := ""
+	gaHeartURL := ""
 
-	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -850,8 +1046,11 @@ func Test_createAlertManagerConfig_WithKey_WithoutURL(t *testing.T) {
 	pdKey := "poiuqwer78902345"
 	wdURL := ""
 	oaURL := ""
+	gaHighURL := ""
+	gaLowURL := ""
+	gaHeartURL := ""
 
-	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -874,8 +1073,12 @@ func Test_createAlertManagerConfig_WithKey_WithoutURL(t *testing.T) {
 func Test_createAlertManagerConfig_WithKey_WithWDURL_WithOAURL(t *testing.T) {
 	pdKey := "poiuqwer78902345"
 	wdURL := "http://theinterwebs"
-	oaURL := "http://dummy-oa-url"
-	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	oaURL := "https://dummy-oa-url"
+	gaHighURL := "https://dummy-gahigh-url"
+	gaLowURL := "https://dummy-galow-url"
+	gaHeartURL := "https://dummy-gaheartbeat-url"
+
+	config := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -884,13 +1087,20 @@ func Test_createAlertManagerConfig_WithKey_WithWDURL_WithOAURL(t *testing.T) {
 	assertEquals(t, "30s", config.Route.GroupWait, "Route.GroupWait")
 	assertEquals(t, "5m", config.Route.GroupInterval, "Route.GroupInterval")
 	assertEquals(t, "12h", config.Route.RepeatInterval, "Route.RepeatInterval")
-	assertEquals(t, 3, len(config.Route.Routes), "Route.Routes")
-	assertEquals(t, 7, len(config.Receivers), "Receivers")
+	assertEquals(t, 5, len(config.Route.Routes), "Route.Routes")
+	assertEquals(t, 10, len(config.Receivers), "Receivers")
 
 	verifyNullReceiver(t, config.Receivers)
 
 	verifyPagerdutyRoute(t, config.Route.Routes[2], exampleManagedNamespaces)
 	verifyPagerdutyReceivers(t, pdKey, exampleProxy, config.Receivers)
+
+	verifyGoalertRoute(t, config.Route.Routes[3], exampleManagedNamespaces)
+	verifyGoalertHighReceivers(t, gaHighURL, exampleProxy, config.Receivers)
+	verifyGoalertLowReceivers(t, gaLowURL, exampleProxy, config.Receivers)
+
+	verifyHeartbeatRoute(t, config.Route.Routes[4])
+	verifyHeartbeatReceiver(t, gaHeartURL, exampleProxy, config.Receivers)
 
 	verifyWatchdogRoute(t, true, config.Route.Routes)
 	verifyWatchdogReceiver(t, wdURL, exampleProxy, true, config.Receivers)
@@ -905,8 +1115,20 @@ func Test_createAlertManagerConfig_WithoutKey_WithoutOA_WithWDURL(t *testing.T) 
 	pdKey := ""
 	wdURL := "http://theinterwebs"
 	oaURL := ""
+	gaHighURL := ""
+	gaLowURL := ""
+	gaHeartURL := ""
 
-	config := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger,
+		pdKey,
+		gaLowURL,
+		gaHighURL,
+		gaHeartURL,
+		wdURL,
+		oaURL,
+		exampleClusterId,
+		exampleProxy,
+		exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -951,6 +1173,24 @@ func createSecret(reconciler *SecretReconciler, secretname string, secretkey str
 		},
 		Data: map[string][]byte{
 			secretkey: []byte(secretdata),
+		},
+	}
+	if err := reconciler.Client.Create(context.TODO(), newsecret); err != nil {
+		panic(err)
+	}
+}
+
+// createSecret creates a fake Secret to use in testing GoAlert. GoAlert has 3 values in a single secret
+func createGoAlertSecret(reconciler *SecretReconciler, secretname string, secreturlLow string, secreturlHigh string, secreturlHeartbeat string, secretdataLow string, secretdataHigh string, secretdataHeartbeat string) {
+	newsecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretname,
+			Namespace: config.OperatorNamespace,
+		},
+		Data: map[string][]byte{
+			secreturlLow:       []byte(secretdataLow),
+			secreturlHigh:      []byte(secretdataHigh),
+			secreturlHeartbeat: []byte(secretdataHeartbeat),
 		},
 	}
 	if err := reconciler.Client.Create(context.TODO(), newsecret); err != nil {
@@ -1006,8 +1246,20 @@ func Test_createPagerdutySecret_Create(t *testing.T) {
 	pdKey := "asdaidsgadfi9853"
 	wdURL := "http://theinterwebs/asdf"
 	oaURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
+	gaHighURL := ""
+	gaLowURL := ""
+	gaHeartURL := ""
 
-	configExpected := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+	configExpected := createAlertManagerConfig(reqLogger,
+		pdKey,
+		gaLowURL,
+		gaHighURL,
+		gaHeartURL,
+		wdURL,
+		oaURL,
+		exampleClusterId,
+		exampleProxy,
+		defaultNamespaces)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1042,11 +1294,14 @@ func Test_createPagerdutySecret_Update(t *testing.T) {
 	pdKey := "asdaidsgadfi9853"
 	wdURL := "http://theinterwebs/asdf"
 	oaURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
+	gaHighURL := ""
+	gaLowURL := ""
+	gaHeartURL := ""
 
 	var ret reconcile.Result
 	var err error
 
-	configExpected := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1082,6 +1337,99 @@ func Test_createPagerdutySecret_Update(t *testing.T) {
 
 	// read config and compare
 	configActual = readAlertManagerConfig(reconciler, req)
+
+	assertEquals(t, configExpected, configActual, "Config Deep Comparison")
+}
+
+// Test_createPagerdutySecret_Create tests writing to the Alertmanager config.
+func Test_createGoalertSecret_Create(t *testing.T) {
+	pdKey := ""
+	wdURL := ""
+	oaURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
+	gaHighURL := "https://dummy-gahigh-url"
+	gaLowURL := "https://dummy-galow-url"
+	gaHeartURL := "https://dummy-gaheartbeat-url"
+
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+
+	verifyInhibitRules(t, configExpected.InhibitRules)
+
+	// prepare environment
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockReadiness := readiness.NewMockInterface(ctrl)
+	mockReadiness.EXPECT().IsReady().Times(1).Return(true, nil)
+	mockReadiness.EXPECT().Result().Times(1).Return(reconcile.Result{})
+	reconciler := createReconciler(t, mockReadiness)
+	createNamespace(reconciler, t)
+	createGoAlertSecret(reconciler, 
+		secretNameGoalert, 
+		secretKeyGoalertLow, 
+		secretKeyGoalertHigh, 
+		secretKeyGoalertHeartbeat, 
+		gaLowURL, 
+		gaHighURL, 
+		gaHeartURL)
+	createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
+	createClusterVersion(reconciler)
+	createClusterProxy(reconciler)
+
+	// reconcile (one event should config everything)
+	req := createReconcileRequest(reconciler, "goalert-secret")
+	ret, err := reconciler.Reconcile(context.TODO(), *req)
+	assertEquals(t, reconcile.Result{}, ret, "Unexpected result")
+	assertEquals(t, nil, err, "Unexpected err")
+
+	// read config and a copy for comparison
+	configActual := readAlertManagerConfig(reconciler, req)
+
+	assertEquals(t, configExpected, configActual, "Config Deep Comparison")
+}
+
+// Test updating the config and making sure it is updated as expected
+func Test_createGoalertSecret_Update(t *testing.T) {
+	pdKey := ""
+	wdURL := ""
+	oaURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
+	gaHighURL := "https://dummy-gahigh-url"
+	gaLowURL := "https://dummy-galow-url"
+	gaHeartURL := "https://dummy-gaheartbeat-url"
+
+	var ret reconcile.Result
+	var err error
+
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+
+	verifyInhibitRules(t, configExpected.InhibitRules)
+
+	// prepare environment
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockReadiness := readiness.NewMockInterface(ctrl)
+	mockReadiness.EXPECT().IsReady().Times(1).Return(true, nil)
+	mockReadiness.EXPECT().Result().Times(1).Return(reconcile.Result{})
+	reconciler := createReconciler(t, mockReadiness)
+	createNamespace(reconciler, t)
+	createGoAlertSecret(reconciler, 
+		secretNameGoalert, 
+		secretKeyGoalertLow, 
+		secretKeyGoalertHigh, 
+		secretKeyGoalertHeartbeat, 
+		gaLowURL, 
+		gaHighURL, 
+		gaHeartURL)
+	createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
+	createClusterVersion(reconciler)
+	createClusterProxy(reconciler)
+
+	// reconcile (one event should config everything)
+	req := createReconcileRequest(reconciler, secretNameGoalert)
+	ret, err = reconciler.Reconcile(context.TODO(), *req)
+	assertEquals(t, reconcile.Result{}, ret, "Unexpected result")
+	assertEquals(t, nil, err, "Unexpected err")
+
+	// read config and compare
+	configActual := readAlertManagerConfig(reconciler, req)
 
 	assertEquals(t, configExpected, configActual, "Config Deep Comparison")
 }
@@ -1127,6 +1475,7 @@ func Test_SecretReconciler(t *testing.T) {
 		pdExists    bool
 		amExists    bool
 		oaExists    bool
+		gaExists    bool
 		otherExists bool
 	}{
 		{
@@ -1135,6 +1484,7 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    false,
 			amExists:    false,
 			oaExists:    false,
+			gaExists:    false,
 			otherExists: false,
 		},
 		{
@@ -1143,6 +1493,7 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    false,
 			amExists:    false,
 			oaExists:    false,
+			gaExists:    false,
 			otherExists: false,
 		},
 		{
@@ -1151,6 +1502,7 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    true,
 			amExists:    false,
 			oaExists:    false,
+			gaExists:    false,
 			otherExists: false,
 		},
 		{
@@ -1159,6 +1511,16 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    false,
 			amExists:    true,
 			oaExists:    false,
+			gaExists:    false,
+			otherExists: false,
+		},
+		{
+			name:        "Test reconcile with GoAlert secret only.",
+			dmsExists:   false,
+			pdExists:    false,
+			amExists:    false,
+			oaExists:    false,
+			gaExists:    true,
 			otherExists: false,
 		},
 		{
@@ -1167,6 +1529,7 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    false,
 			amExists:    false,
 			oaExists:    false,
+			gaExists:    false,
 			otherExists: true,
 		},
 		{
@@ -1175,6 +1538,7 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    true,
 			amExists:    false,
 			oaExists:    false,
+			gaExists:    false,
 			otherExists: false,
 		},
 		{
@@ -1183,6 +1547,16 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    true,
 			amExists:    true,
 			oaExists:    false,
+			gaExists:    false,
+			otherExists: false,
+		},
+		{
+			name:        "Test reconcile with ga & am secrets.",
+			dmsExists:   false,
+			pdExists:    false,
+			amExists:    true,
+			oaExists:    false,
+			gaExists:    true,
 			otherExists: false,
 		},
 		{
@@ -1191,6 +1565,7 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    false,
 			amExists:    true,
 			oaExists:    false,
+			gaExists:    false,
 			otherExists: false,
 		},
 		{
@@ -1199,6 +1574,16 @@ func Test_SecretReconciler(t *testing.T) {
 			pdExists:    true,
 			amExists:    true,
 			oaExists:    false,
+			gaExists:    false,
+			otherExists: false,
+		},
+		{
+			name:        "Test reconcile with ga, pd, dms, and am secrets.",
+			dmsExists:   true,
+			pdExists:    true,
+			amExists:    true,
+			oaExists:    false,
+			gaExists:    true,
 			otherExists: false,
 		},
 	}
@@ -1214,10 +1599,13 @@ func Test_SecretReconciler(t *testing.T) {
 		pdKey := ""
 		wdURL := ""
 		oaURL := ""
+		gaLowURL := ""
+		gaHighURL := ""
+		gaHeartURL := ""
 
 		// Create the secrets for this specific test.
 		if tt.amExists {
-			writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig(reqLogger, "", "", "", "", "", defaultNamespaces))
+			writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, "", "", defaultNamespaces))
 		}
 		if tt.dmsExists {
 			wdURL = "https://hjklasdf09876"
@@ -1230,11 +1618,25 @@ func Test_SecretReconciler(t *testing.T) {
 			pdKey = "asdfjkl123"
 			createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
 		}
+		if tt.gaExists {
+			gaHighURL = "https://dummy-gahigh-url"
+			gaLowURL = "https://dummy-galow-url"
+			gaHeartURL = "https://dummy-gaheartbeat-url"
+			createGoAlertSecret(reconciler, 
+				secretNameGoalert, 
+				secretKeyGoalertLow, 
+				secretKeyGoalertHigh, 
+				secretKeyGoalertHeartbeat, 
+				gaLowURL, 
+				gaHighURL, 
+				gaHeartURL)
+		}
 		if tt.oaExists {
 			oaURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
 			createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 		}
-		configExpected := createAlertManagerConfig(reqLogger, pdKey, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+
+		configExpected := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
 
 		verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1262,14 +1664,16 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 		readyErr  bool
 		expectDMS bool
 		expectPD  bool
+		expectGA  bool
 		expectOA  bool
 	}{
 		{
-			name:      "Cluster not ready: don't configure PD or OA.",
+			name:      "Cluster not ready: don't configure GA, PD or OA.",
 			ready:     false,
 			readyErr:  false,
 			expectDMS: true,
 			expectPD:  false,
+			expectGA:  false,
 			expectOA:  false,
 		},
 		{
@@ -1279,6 +1683,7 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 			readyErr:  false,
 			expectDMS: true,
 			expectPD:  true,
+			expectGA:  true,
 			expectOA:  true,
 		},
 		{
@@ -1287,6 +1692,7 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 			readyErr:  true,
 			expectDMS: false,
 			expectPD:  false,
+			expectGA:  false,
 			expectOA:  false,
 		},
 	}
@@ -1305,17 +1711,28 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 		createClusterVersion(reconciler)
 		createClusterProxy(reconciler)
 
-		writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig(reqLogger, "", "", "", "", "", defaultNamespaces))
+		writeAlertManagerConfig(reconciler, reqLogger, createAlertManagerConfig(reqLogger, "", "", "", "", "", "", "", "", defaultNamespaces))
 
 		pdKey := "asdfjkl123"
 		dmsURL := "https://hjklasdf09876"
 		oaURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", ocmAgentService, ocmAgentNamespace, 9999, ocmAgentWebhookPath)
+		gaHighURL := "https://dummy-gahigh-url"
+		gaLowURL := "https://dummy-galow-url"
+		gaHeartURL := "https://dummy-gaheartbeat-url"
 
 		// Create the secrets for this specific test.
 		// We're testing that Reconcile parlays the PD/DMS secrets into the AM config as
 		// appropriate. So we always start with those two secrets
 		createSecret(reconciler, secretNameDMS, secretKeyDMS, dmsURL)
 		createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
+		createGoAlertSecret(reconciler, 
+			secretNameGoalert, 
+			secretKeyGoalertLow, 
+			secretKeyGoalertHigh, 
+			secretKeyGoalertHeartbeat, 
+			gaLowURL, 
+			gaHighURL, 
+			gaHeartURL)
 
 		// However, we expect the AM config to be updated only according to the test spec
 		if !tt.expectDMS {
@@ -1324,12 +1741,17 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 		if !tt.expectPD {
 			pdKey = ""
 		}
+		if !tt.expectGA {
+			gaHighURL = ""
+			gaLowURL = ""
+			gaHeartURL = ""
+		}
 		if tt.expectOA {
 			createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 		} else {
 			oaURL = ""
 		}
-		configExpected := createAlertManagerConfig(reqLogger, pdKey, dmsURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+		configExpected := createAlertManagerConfig(reqLogger, pdKey, gaLowURL, gaHighURL, gaHeartURL, dmsURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
 
 		verifyInhibitRules(t, configExpected.InhibitRules)
 

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -942,14 +942,14 @@ func Test_readOCMAgentServiceURLFromConfig(t *testing.T) {
 
 func Test_createPagerdutyRoute(t *testing.T) {
 	// test the structure of the Route is sane
-	route := createSubroutes(reqLogger, defaultNamespaces, "pagerduty")
+	route := createSubroutes(defaultNamespaces, Pagerduty)
 
 	verifyPagerdutyRoute(t, route, defaultNamespaces)
 }
 
 func Test_createGoalertSubroute(t *testing.T) {
 	// test the structure of the Route is sane
-	route := createSubroutes(reqLogger, defaultNamespaces, "goalert")
+	route := createSubroutes(defaultNamespaces, GoAlert)
 
 	verifyGoalertRoute(t, route, defaultNamespaces)
 }

--- a/manifests/05_prometheusrules.yaml
+++ b/manifests/05_prometheusrules.yaml
@@ -15,6 +15,14 @@ spec:
       for: 5m
       labels:
         severity: critical
+    - alert: ConfigureAlertmanagerOperatorMismatchGaSRE
+      annotations:
+        message: "Mismatch between GA secret and GA AlertManager config"
+        link_url: "https://access.redhat.com/articles/4165971"
+      expr: ga_secret_exists + am_secret_contains_ga == 1
+      for: 5m
+      labels:
+        severity: critical
     - alert: ConfigureAlertmanagerOperatorMismatchPdSRE
       annotations:
         message: "Mismatch between PD secret and PD AlertManager config"
@@ -31,4 +39,3 @@ spec:
       for: 5m
       labels:
         severity: critical
-

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,7 +32,7 @@ const (
 var (
 	metricGASecretExists = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "ga_secret_exists",
-		Help: "Pager Duty secret exists",
+		Help: "GoAlert secret exists",
 	}, []string{"name"})
 	metricPDSecretExists = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pd_secret_exists",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,6 +30,10 @@ const (
 )
 
 var (
+	metricGASecretExists = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ga_secret_exists",
+		Help: "Pager Duty secret exists",
+	}, []string{"name"})
 	metricPDSecretExists = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pd_secret_exists",
 		Help: "Pager Duty secret exists",
@@ -41,6 +45,10 @@ var (
 	metricAMSecretExists = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "am_secret_exists",
 		Help: "AlertManager Config secret exists",
+	}, []string{"name"})
+	metricAMSecretContainsGA = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "am_secret_contains_ga",
+		Help: "AlertManager Config contains configuration for GoAlert",
 	}, []string{"name"})
 	metricAMSecretContainsPD = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "am_secret_contains_pd",
@@ -60,9 +68,11 @@ var (
 	}, []string{"name"})
 
 	metricsList = []prometheus.Collector{
+		metricGASecretExists,
 		metricPDSecretExists,
 		metricDMSSecretExists,
 		metricAMSecretExists,
+		metricAMSecretContainsGA,
 		metricAMSecretContainsPD,
 		metricAMSecretContainsDMS,
 		metricManNSConfigMapExists,
@@ -100,15 +110,19 @@ func RegisterMetrics() error {
 func UpdateSecretsMetrics(list *corev1.SecretList, amconfig *alertmanager.Config) {
 
 	// Default to false.
+	gaSecretExists := false
 	pdSecretExists := false
 	dmsSecretExists := false
 	amSecretExists := false
+	amSecretContainsGA := false
 	amSecretContainsPD := false
 	amSecretContainsDMS := false
 
 	// Update the metric if the secret is found in the SecretList.
 	for _, secret := range list.Items {
 		switch secret.Name {
+		case "goalert-secret":
+			gaSecretExists = true
 		case "pd-secret":
 			pdSecretExists = true
 		case "dms-secret":
@@ -118,8 +132,15 @@ func UpdateSecretsMetrics(list *corev1.SecretList, amconfig *alertmanager.Config
 		}
 	}
 
-	// Check for the presence of PD and DMS configs inside the AlertManager config and report metrics.
+	// Check for the presence of GoAlert, PD and DMS configs inside the AlertManager config and report metrics.
 	if amSecretExists {
+		if gaSecretExists {
+			for _, receiver := range amconfig.Receivers {
+				if receiver.Name == "goalert" {
+					amSecretContainsGA = true
+				}
+			}
+		}
 		if pdSecretExists {
 			for _, receiver := range amconfig.Receivers {
 				if receiver.Name == "pagerduty" {
@@ -137,6 +158,11 @@ func UpdateSecretsMetrics(list *corev1.SecretList, amconfig *alertmanager.Config
 	}
 
 	// Only set metrics once per run.
+	if gaSecretExists {
+		metricGASecretExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(1))
+	} else {
+		metricGASecretExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(0))
+	}
 	if pdSecretExists {
 		metricPDSecretExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(1))
 	} else {
@@ -151,6 +177,11 @@ func UpdateSecretsMetrics(list *corev1.SecretList, amconfig *alertmanager.Config
 		metricAMSecretExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(1))
 	} else {
 		metricAMSecretExists.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(0))
+	}
+	if amSecretContainsGA {
+		metricAMSecretContainsGA.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(1))
+	} else {
+		metricAMSecretContainsGA.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(0))
 	}
 	if amSecretContainsPD {
 		metricAMSecretContainsPD.With(prometheus.Labels{"name": config.OperatorName}).Set(float64(1))


### PR DESCRIPTION
Adding GoAlert to CAMO. This is a FedRAMP requirement to configure GoAlert.

# Changes

- 3 receivers (goalert, goalert-high, goalert-heartbeat) added for GoAlert to replace PagerDuty and DMS services
- 2 routes (goalert and goalert-heartbeat) added for GoAlert to replace PagerDuty and DMS services
- Additional logic added to support GoAlert