### PR TITLE
Revert OSD-14347

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@
 ## Summary
 The Configure Alertmanager Operator was created for the OpenShift Dedicated platform to dynamically manage Alertmanager configurations based on the presence or absence of secrets containing a Pager Duty RoutingKey and [Dead Man's Snitch](https://deadmanssnitch.com) URL. When the secret is created/updated/deleted, the associated Receiver and Route will be created/updated/deleted within the Alertmanager config.
 
-The operator will only configure a Dead Man's Snitch watchdog receiver if a Pager Duty receiver is also configured to be present. This is in order to deliberately trigger a watchdog timeout if for some reason Pager Duty has not been configured, as both are required.  
-
 The operator contains the following components:
 
 * Secret controller: watches the `openshift-monitoring` namespace for any changes to relevant Secrets or ConfigMaps that are used in the configuration of Alertmanager. For more information on this see [Secret Controller](#secret-controller) below.


### PR DESCRIPTION
This is a revert of change [OSD-14347](https://issues.redhat.com//browse/OSD-14347) to not configure DMS if PD is not configured.

This is having a side-effect of causing CHGMs for new clusters.

Previously CAMO's behaviour was to not configure PagerDuty if the `osd-cluster-ready` job had not finished. With the changes of [OSD-14347](https://issues.redhat.com//browse/OSD-14347), this now meant that DMS was also not configured if `osd-cluster-ready` had not finished.

Because `osd-cluster-ready` can take quite a while to finish, this is raising CHGMs because DMS does not get configured.