### PR TITLE
OSD-14149 : Modified the config to enable CannotRetrieveUpdates alert…

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -297,6 +297,8 @@ func createSubroutes(namespaceList []string, receiver receiverType) (*alertmanag
 		// regex tests: https://regex101.com/r/Rn6F5A/1
 		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-[123]$"}, Match: map[string]string{"alertname": "MachineWithoutValidNode", "namespace": "openshift-machine-api"}},
 		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-[123]$"}, Match: map[string]string{"alertname": "MachineWithNoRunningPhase", "namespace": "openshift-machine-api"}},
+		// https://issues.redhat.com/browse/OSD-14149
+		{Receiver: receiverMakeItCritical, Match: map[string]string{"alertname": "CannotRetrieveUpdates"}},
 		// Silence anything intended for OCM Agent
 		// https://issues.redhat.com/browse/SDE-1315
 		{Receiver: receiverNull, Match: map[string]string{managedNotificationLabel: "true"}},
@@ -379,8 +381,6 @@ func createSubroutes(namespaceList []string, receiver receiverType) (*alertmanag
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "IdentityProviderConfig_Error"}},
 		//https://issues.redhat.com/browse/OSD-8320
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "OAuthServerConfigObservation_Error"}},
-		// https://issues.redhat.com/browse/OSD-6327
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "CannotRetrieveUpdates"}},
 		//https://issues.redhat.com/browse/OSD-6559
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusNotIngestingSamples", "namespace": "openshift-user-workload-monitoring"}},
 		//https://issues.redhat.com/browse/OSD-7671


### PR DESCRIPTION
This alert was disabled due to [bug 2109374](https://bugzilla.redhat.com/show_bug.cgi?id=2109374) in [OSD-6327](https://issues.redhat.com/browse/OSD-6327)

If this alert fires it means the cluster version operator has not retrieved updates in a reasonable amount of time. This PR is to re-enable the alert as critical.

The impact to the cluster is that the CVO is not able to refresh the available updates successfully. This impacts the customer schedules because the version that the customer wishes to upgrade to is not in the list of available upgrades, the MUO does not proceed with the upgrade and it is eventually cancelled.

When this happens, we tend to get OHSS queries from the customer asking why an upgrade was canceled.