### PR TITLE
Adds supression to ClusterOperatorDown on monitoring operator

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -383,6 +383,8 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "IdentityProviderConfig_Error"}},
 		//https://issues.redhat.com/browse/OSD-8320
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "authentication", "reason": "OAuthServerConfigObservation_Error"}},
+		//https://issues.redhat.com/browse/OSD-16158
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "monitoring"}},
 		//https://issues.redhat.com/browse/OSD-6559
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "PrometheusNotIngestingSamples", "namespace": "openshift-user-workload-monitoring"}},
 		//https://issues.redhat.com/browse/OSD-7671


### PR DESCRIPTION
Suppresses the ClusterOperatorDown alert for the monitoring operator. Allows us to break this alert up with https://github.com/openshift/managed-cluster-config/pull/1641 and eventually send the multiple prometheus instances to OAO to send servicelogs.