### PR TITLE
Suppresses NodeFileDescriptorLimit Alerts in lieu of other SRE-flavored alerts for the same.

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -314,6 +314,8 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CPUThrottlingHigh"}},
 		// https://issues.redhat.com/browse/OSD-3010
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemSpaceFillingUp", "severity": "warning"}},
+		// https://issues.redhat.com/browse/OSD-12379
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFileDescriptorLimit"}},
 		// https://issues.redhat.com/browse/OSD-2611
 		{Receiver: receiverNull, Match: map[string]string{"namespace": "openshift-customer-monitoring"}},
 		// https://issues.redhat.com/browse/OSD-3569


### PR DESCRIPTION
Routes NodeFileDescriptorLimit alerts to the null receiver since there are now two new alerts, one for ControlPlane/Infra nodes and one for Worker nodes, and the worker nodes one is set to automatically send an SL to the customer, skipping SRE.

https://issues.redhat.com/browse/OSD-12379