### PR TITLE
Prefer scheduling registry pod onto infra nodes

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -35,6 +35,13 @@ objects:
         name: configure-alertmanager-operator-registry
         namespace: openshift-monitoring
       spec:
+        grpcPodConfig:
+          nodeSelector:
+            node-role.kubernetes.io: infra
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
         image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
         affinity:
           nodeAffinity:


### PR DESCRIPTION
This commit specifies .spec.grpcPodConfig.nodeSelector and .spec.grpdPodConfig.tolerations to schedule this operator's registry pod to infra nodes when possible.

[OSD-6629](https://issues.redhat.com//browse/OSD-6629)