### PR TITLE
Routes UserWorkloadMonitoring based CODown errors to null receiver

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -453,6 +453,10 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// for non-default ingresscontroller in 4.13+ when user can control their own
 		// https://issues.redhat.com/browse/OSD-16014
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "HAProxyDown"}},
+
+		// Route UWM-misconfiguration alerts to null
+		// https://issues.redhat.com/browse/OSD-17651
+		{Receiver: receiverNull, MatchRE: map[string]string{"reason": "UpdatingPrometheusUserWorkloadFailed"}, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "monitoring"}},
 	}
 
 	// Silence insights in FedRAMP until its made available in the environment


### PR DESCRIPTION
This PR routes CODown errors with a `UserWorkload` reason to the null receiver.

This should alleviate some pressure on SRE for customer misconfigurations.

We can circle back to routing this to the customer as an RFE, for now we should just get this off of SRE on-call's plate since the alerts are currently just silenced anyway.

https://issues.redhat.com/browse/OSD-17651