### PR TITLE
feat(OSD-19000): mute critical KubePersistentVolumeFillingUp as it is handled by OAO

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -337,8 +337,9 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ImagePruningDisabled"}},
 		// https://issues.redhat.com/browse/OSD-3794
 		{Receiver: receiverNull, Match: map[string]string{"severity": "info"}},
-		// https://issues.redhat.com/browse/OSD-8665
-		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubePersistentVolumeFillingUp", "severity": "warning", "namespace": "openshift-logging"}},
+		// https://issues.redhat.com/browse/OSD-8665 - Warning
+		// https://issues.redhat.com/browse/OSD-19000 - Critical
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubePersistentVolumeFillingUp", "namespace": "openshift-logging"}},
 		// https://issues.redhat.com/browse/OSD-3973
 		{Receiver: receiverNull, MatchRE: map[string]string{"namespace": alertmanager.PDRegexLP}, Match: map[string]string{"alertname": "PodDisruptionBudgetLimit"}},
 		// https://issues.redhat.com/browse/OSD-3973


### PR DESCRIPTION
Disable Critical KubePersistentVolumeFillingUp as it is is handled by OAO. 
To allow OAO handling it directly, we now define the upstream expression directly in MCC instead of counting active alerts for this (https://github.com/openshift/managed-cluster-config/pull/1895) . 

Fixes https://issues.redhat.com/browse/OSD-19000
