### PR TITLE
OSD-19439: Route CertificateIsAboutToExpire to nullReceiver

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -454,6 +454,9 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// for non-default ingresscontroller in 4.13+ when user can control their own
 		// https://issues.redhat.com/browse/OSD-16014
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "HAProxyDown"}},
+		// Route CertificateIsAboutToExpire alert to null
+		// https://issues.redhat.com/browse/OSD-19439
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "CertificateIsAboutToExpire"}},
 	}
 
 	// Silence insights in FedRAMP until its made available in the environment


### PR DESCRIPTION
This is a tentative PR to tackle https://issues.redhat.com/browse/OSD-19439. 

`CertificateIsAboutToExpire` is an alert coming from the community [cert-utils-operator](https://github.com/redhat-cop/cert-utils-operator) - we temporarily relaxed our webhook to allow creating this alerting rule in `openshift-monitoring`, see https://issues.redhat.com/browse/OSD-13909. 

From my understanding, we can just route this to `nullReceiver` anyway, as the alert will still be available for the customer in the console. 