### PR TITLE
[OSD-19310] - remove GoAlert catchall

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -467,16 +467,6 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		)
 	}
 
-	// GoAlert specific settings
-	if receiver == GoAlert {
-		// Overcome webhook limitations
-		subroute = append(subroute, []*alertmanager.Route{
-			{Receiver: receiverCritical, Match: map[string]string{"severity": "critical"}},
-			{Receiver: receiverError, Match: map[string]string{"severity": "error"}},
-			{Receiver: receiverWarning, Match: map[string]string{"severity": "warning"}},
-		}...)
-	}
-
 	for _, namespace := range namespaceList {
 		subroute = append(subroute, []*alertmanager.Route{
 			// https://issues.redhat.com/browse/OSD-3086


### PR DESCRIPTION
Why are we making this change?
Since introducing GoAlert, we have received a few alerts to GoAlert that were not at parity with PagerDuty alerts.  Comparing the raw alertmanager.yaml from the pod, the only difference is this section was added to catch anything that may have otherwise slipped through the cracks.  

How was it tested?
This has been tested using an image built with this change and posting the alert to alertmanger.  The unwanted alerts were not delivered to GoAlert, while all other alerts were.