### PR TITLE
Add GoAlert specific routing for namespaces

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -469,12 +469,13 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 
 	// GoAlert specific settings
 	if receiver == GoAlert {
-		// Overcome webhook limitations
-		subroute = append(subroute, []*alertmanager.Route{
-			{Receiver: receiverCritical, Match: map[string]string{"severity": "critical"}},
-			{Receiver: receiverError, Match: map[string]string{"severity": "error"}},
-			{Receiver: receiverWarning, Match: map[string]string{"severity": "warning"}},
-		}...)
+		for _, namespace := range namespaceList {
+			subroute = append(subroute, []*alertmanager.Route{
+				{Receiver: receiverCritical, MatchRE: map[string]string{"namespace": namespace}, Match: map[string]string{"exported_namespace": "", "prometheus": "openshift-monitoring/k8s", "severity": "critical"}},
+				{Receiver: receiverError, MatchRE: map[string]string{"namespace": namespace}, Match: map[string]string{"exported_namespace": "", "prometheus": "openshift-monitoring/k8s", "severity": "error"}},
+				{Receiver: receiverWarning, MatchRE: map[string]string{"namespace": namespace}, Match: map[string]string{"exported_namespace": "", "prometheus": "openshift-monitoring/k8s", "severity": "warning"}},
+			}...)
+		}
 	}
 
 	for _, namespace := range namespaceList {


### PR DESCRIPTION
Why are we making this change?
Since introducing GoAlert, we have received a few pageable alerts to GoAlert that were not at parity with PagerDuty alerts. I have added logic to loop through the defined openshift namespaces and match their severity to the expected GoAlert receiver.  With the new configuration, we still receive the alert for customer namespaces, but it is delivered to a non-paging GoAlert receiver.

How was it tested?
This has been tested using an image built with this change and posting the alert to alertmanger. The unwanted alerts were delivered to the GoAlert non-paging low receiver.  Adjusting the alert to an openshift namespace, we receive the alert to the pagable "high" GoAlert receiver.