### PR TITLE
OSD-18515: Making sure KubePersistentVolumeFillingUp alerts on 'openshift-user-workload-monitoring' namespace are no more routed to Pagerduty

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -338,6 +338,8 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// https://issues.redhat.com/browse/OSD-3794
 		{Receiver: receiverNull, Match: map[string]string{"severity": "info"}},
 		// https://issues.redhat.com/browse/OSD-8665 - Warning
+		// https://issues.redhat.com/browse/OSD-18515
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubePersistentVolumeFillingUp", "namespace": "openshift-user-workload-monitoring"}},
 		// https://issues.redhat.com/browse/OSD-19000 - Critical
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "KubePersistentVolumeFillingUp", "namespace": "openshift-logging"}},
 		// https://issues.redhat.com/browse/OSD-3973


### PR DESCRIPTION
Those alerts will now indeed be handled the `ocm-agent-operator`

**Do not merge yet!**
The following PR need to be merged first:
https://github.com/openshift/managed-cluster-config/pull/1940