### PR TITLE
[OSD-19769] Silence ClusterOperatorDown for the monitoring cluster operator

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -461,6 +461,13 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
 	}
 
+	if !config.IsFedramp() {
+        // Route ClusterOperatorDown for monitoring to null receiver https://issues.redhat.com/browse/OSD-19769
+        subroute = append(subroute,
+			&alertmanager.Route{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "monitoring"}},
+		)
+    }
+
 	for _, namespace := range namespaceList {
 		if receiver == Pagerduty {
 			subroute = append(subroute, []*alertmanager.Route{


### PR DESCRIPTION
The ClusterOperatorDown alert for monitoring is being substituted by an error budget burn as part of https://issues.redhat.com/browse/OSD-19769

To merge after https://github.com/openshift/managed-cluster-config/pull/1962