### PR TITLE
align OWNERS with managed-cluster-config OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,23 @@
 reviewers:
-- NautiluX
-- fahlmant
-- dustman9000
-- wanghaoran1988
+- srep-functional-leads
+- srep-team-leads
+- clcollins
+- hectorakemp
+- robotmaxtron
+- typeid
+- xiaoyu74
+- zmird-r
+- maorfr
 approvers:
-- NautiluX
-- fahlmant
-- dustman9000
-- wanghaoran1988
+- srep-functional-leads
+- srep-team-leads
+- clcollins
+- hectorakemp
+- robotmaxtron
+- typeid
+- xiaoyu74
+- zmird-r
+- maorfr
 maintainers:
 - NautiluX
 - fahlmant


### PR DESCRIPTION
changes in this repository often correspond to changes in https://github.com/openshift/managed-cluster-config

ref: https://github.com/openshift/managed-cluster-config/pull/1935

enabling more people to review and approve PRs to this repository should help with reducing wait time.

related ticket: https://issues.redhat.com/browse/OSD-20294