### PR TITLE
OSD-23026: Update regex for master node names to account for CPMS

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161.1715068733
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1161.1715068733
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -297,8 +297,8 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// https://issues.redhat.com/browse/OSD-11298
 		// indications that master nodes have been terminated should be critical
 		// regex tests: https://regex101.com/r/Rn6F5A/1
-		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-[123]$"}, Match: map[string]string{"alertname": "MachineWithoutValidNode", "namespace": "openshift-machine-api"}},
-		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-[123]$"}, Match: map[string]string{"alertname": "MachineWithNoRunningPhase", "namespace": "openshift-machine-api"}},
+		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-.*[0-9]+$"}, Match: map[string]string{"alertname": "MachineWithoutValidNode", "namespace": "openshift-machine-api"}},
+		{Receiver: receiverCritical, MatchRE: map[string]string{"name": "^.+-master-.*[0-9]+$"}, Match: map[string]string{"alertname": "MachineWithNoRunningPhase", "namespace": "openshift-machine-api"}},
 		// Route CannotRetrieveUpdates to null, created CannotRetrieveUpdatesSRE in managed-cluster-config to address https://issues.redhat.com/browse/OSD-14149
 		// https://issues.redhat.com/browse/OCPBUGS-11636
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CannotRetrieveUpdates"}},


### PR DESCRIPTION
In https://issues.redhat.com/browse/OSD-23026 found the regex for machine names was no longer valid with the introducction of CPMS. Impacts two alerts:

* MachineWithNoRunningPhase
* MachineWithoutValidNode 

And results in those alerts not having severity bumped to critical when sent to PD (they stay at warning) and are therefore not raised to on-call.