### PR TITLE
OSD-22337 route some customer alerts to null receiver

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1086
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1086
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -457,6 +457,13 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// Route ClusterOperatorDown for insights to null receiver https://issues.redhat.com/browse/OSD-19800
 		// Also needs to be silenced for FedRAMP until its made available in the environment https://issues.redhat.com/browse/OSD-13685
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
+		// Route some customer defined alerts to null receiver
+		// https://issues.redhat.com/browse/OSD-22337
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "memory-request"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "cpu-request"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "daemonset-availability"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "sonarqube-ErrorBudgetBurn"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "DnsDefaultPodRestarted"}},
 	}
 
 	if !config.IsFedramp() {


### PR DESCRIPTION
There are some customer defined alerts which are picked up by CAMO and routed to Red Hat pagerduty due to customer set some labels with Red Hat managed namespaces.

Adding some route rules to redirect those alerts to NULL receiver so that Red Hat SRE will not be paged.

Rule has been tested on a stg cluster.
