### PR TITLE
Updating the doc to be warn about matching rules getting ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The operator contains the following components:
 
 The Secret Controller watches over the resources in the table below. Changes to these resources will prompt the controller to reconcile.
 
+**Note**: When making changes to [matching rules](https://github.com/openshift/configure-alertmanager-operator/blob/master/controllers/secret_controller.go) in secret controller, check to make sure the newly added rules won't get ignored. e.g. when a matching rule above the new rule captures it and don't continue to match the following rules, the new matching rule will be ignored. [ocm-agent matching](https://github.com/openshift/configure-alertmanager-operator/blob/master/controllers/secret_controller.go#L504) rule is an example, if an alert matches this rule, the rules after will never gets ignored.
+
 | Resource Type | Resource Namespace/Name                   | Reason for watching                                                                                                                                    |
 |---------------|-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Secret        | `openshift-monitoring/alertmanager-main`  | Represents the Alertmanager Configuration that the operator creates/maintains the state of.                                                            |

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1086
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1052.1724178568
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1086
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
As per the investigation in the [JIRA [OSD-20981](https://issues.redhat.com//browse/OSD-20981)](https://issues.redhat.com/browse/OSD-20981) placement of the matching rules in secret_controller.go is important.
 
Ref: [OSD-20981](https://issues.redhat.com//browse/OSD-20981)