### PR TITLE
OSD-24906: Read SOP links from labels of alertrule, if available

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -530,7 +530,7 @@ func createOCMAgentReceiver(ocmAgentURL string) []*alertmanager.Receiver {
 func createPagerdutyConfig(pagerdutyRoutingKey, clusterID string, clusterProxy string) *alertmanager.PagerdutyConfig {
 	detailsMap := map[string]string{
 		"alert_name":   `{{ .CommonLabels.alertname }}`,
-		"link":         `{{ if .CommonAnnotations.runbook_url }}{{ .CommonAnnotations.runbook_url }}{{ else if .CommonAnnotations.link }}{{ .CommonAnnotations.link }}{{ else }}https://github.com/openshift/ops-sop/tree/master/v4/alerts/{{ .CommonLabels.alertname }}.md{{ end }}`,
+		"link":         `{{ if .CommonAnnotations.runbook_url }}{{ .CommonAnnotations.runbook_url }}{{ else if .CommonAnnotations.link }}{{ .CommonAnnotations.link }}{{ else if .CommonLabels.link }}{{ .CommonLabels.link }}{{ else }}https://github.com/openshift/ops-sop/tree/master/v4/alerts/{{ .CommonLabels.alertname }}.md{{ end }}`,
 		"ocm_link":     fmt.Sprintf("https://console.redhat.com/openshift/details/%s", clusterID),
 		"num_firing":   `{{ .Alerts.Firing | len }}`,
 		"num_resolved": `{{ .Alerts.Resolved | len }}`,


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OSD-24906

Currently, alerts use one of the following fields to define a link to an SOP:

- Annotations.runbook_url
- Annotations.link
- Labels.link

This PR adds the missing check for Labels.link so that alerts such as https://redhat.pagerduty.com/incidents/Q0HL1LX6X2GYSH do not show multiple different SOP links.




