### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -32,6 +32,8 @@ objects:
         labels:
           opsrc-datastore: "true"
           opsrc-provider: redhat
+        annotations:
+          openshift.io/required-scc: anyuid
         name: configure-alertmanager-operator-registry
         namespace: openshift-monitoring
       spec:

--- a/deploy/04_operator.yaml
+++ b/deploy/04_operator.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         name: configure-alertmanager-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       serviceAccountName: configure-alertmanager-operator
       affinity:


### PR DESCRIPTION
Pin `configure-alertmanager-operator` to use the restricted-v2 SCC and `configure-alertmanager-operator-registry` to use the anyuid SCC.