### PR TITLE
OSD-28521: Route etcdExcessiveDatabaseGrowth to SRE

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -353,7 +353,7 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// # for elasticsearch
 		// yq '.spec.groups[].rules[].alert | select( . != null) ' ../managed-cluster-config/resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml | sort -u | awk '{print "{Receiver: receiverNull, Match: map[string]string{\"alertname\": \"" $1 "\", \"namespace\": \"openshift-logging\"}},"}'
 		// ```
-		// pass all of the alerts that are SRE related to PD/GoAlert
+		// pass all the alerts that are SRE related to PD/GoAlert
 		{Receiver: receiverCommon, MatchRE: map[string]string{"alertname": "^.*SRE$"}, Match: map[string]string{"namespace": "openshift-logging"}},
 		// fluentd alerts
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "FluentDHighErrorRate", "namespace": "openshift-logging"}},
@@ -446,6 +446,9 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// Route ClusterOperatorDown for insights to null receiver https://issues.redhat.com/browse/OSD-19800
 		// Also needs to be silenced for FedRAMP until its made available in the environment https://issues.redhat.com/browse/OSD-13685
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
+		// Route etcdExcessiveDatabaseGrowth warning level alerts to SRE as critical to aid in reducing incidents related
+		// to customers exceeding etcd's max database size.
+		{Receiver: receiverCritical, Match: map[string]string{"alertname": "etcdExcessiveDatabaseGrowth"}},
 	}
 
 	if !config.IsFedramp() {


### PR DESCRIPTION
As SRE continues to evolve our story for how we support customers who knock over etcd, we should utilize all alerts we can to give ourselves some heads up when a cluster might be falling over.

OCP includes this warning level alert `etcdExcessiveDatabaseGrowth` [here](https://github.com/openshift/cluster-etcd-operator/blob/release-4.16/manifests/0000_90_etcd-operator_03_prometheusrule.yaml#L100) that we can use as a signal that a cluster might fill up in the next 4 hours.

By routing this to primary (re-writing it to critical), we can hopefully catch some runaway etcd usage earlier. If we find this is too noisy or not valuable we can always revert, but the risk of slightly more noise is out weighed by the incident burden.