### PR TITLE
[OSD-28223] Silence all NodeFilesystem related alerts

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -312,8 +312,11 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// TODO: Remove CPUThrottlingHigh entry after all OSD clusters upgrade to 4.6 and above version
 		// https://issues.redhat.com/browse/OSD-6351 based on https://bugzilla.redhat.com/show_bug.cgi?id=1843346
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CPUThrottlingHigh"}},
-		// https://issues.redhat.com/browse/OSD-3010 && https://issues.redhat.com/browse/OSD-14017
+		// https://issues.redhat.com/browse/OSD-28223
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemSpaceFillingUp"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemFilesFillingUp"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemAlmostOutOfSpace"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFilesystemAlmostOutOfFiles"}},
 		// https://issues.redhat.com/browse/OSD-12379
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "NodeFileDescriptorLimit"}},
 		// https://issues.redhat.com/browse/OSD-2611


### PR DESCRIPTION
Silence alert which is handled using ocm-agent. ref [#2380](https://github.com/openshift/managed-cluster-config/pull/2380)
