### PR TITLE
Set applyBehavior to CreateOrUpdate

### DIFF
--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -25,6 +25,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: "true"
     resourceApplyMode: Sync
+    applyBehavior: CreateOrUpdate
     resources:
     - apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource


### PR DESCRIPTION
# Overview

We are working on a SPIKE where we are testing a change of Hive's default apply mode to `CreateOrUpdate`. 
So far in other operators (RMO/Velero) we have observed this change is helping avoid conflicts between OLM and Hive.
We would like to test one more operator before declaring victory - hence this PR. 

## Background 
By default hive will perform the equivalent of a `kubectl apply` when syncing a SSS. Swapping to the `CreateOrUpdate` mode will update hive to perform a `kubectl patch` - and this will hopefully prevent the issues we've been seeing. 

(A in depth explanation can be found here: https://issues.redhat.com/browse/HIVE-2666?focusedId=26162937&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26162937 )

# Fixes
- https://issues.redhat.com/browse/OSD-28836 