### PR TITLE
Set applyBehavior to CreateOrUpdate

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1739286367
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/build/templates/olm-artifacts-template.yaml.tmpl
+++ b/build/templates/olm-artifacts-template.yaml.tmpl
@@ -25,6 +25,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: "true"
     resourceApplyMode: Sync
+    applyBehavior: CreateOrUpdate
     resources:
     - apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource


### PR DESCRIPTION
# Overview

We are working on a SPIKE where we are testing a change of Hive's default apply mode to `CreateOrUpdate`. 
So far in other operators (RMO/Velero) we have observed this change is helping avoid conflicts between OLM and Hive.
We would like to test one more operator before declaring victory - hence this PR. 

## Background 
By default hive will perform the equivalent of a `kubectl apply` when syncing a SSS. Swapping to the `CreateOrUpdate` mode will update hive to perform a `kubectl patch` - and this will hopefully prevent the issues we've been seeing. 

(A in depth explanation can be found here: https://issues.redhat.com/browse/HIVE-2666?focusedId=26162937&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-26162937 )

# Fixes
- https://issues.redhat.com/browse/OSD-28836 