### PR TITLE
Allow OLM range skip

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	OperatorName      string = "configure-alertmanager-operator"
-	OperatorNamespace string = "openshift-monitoring"
+	OperatorName       string = "configure-alertmanager-operator"
+	OperatorNamespace  string = "openshift-monitoring"
+	EnableOLMSkipRange        = "true"
 )
 
 var isFedramp = false


### PR DESCRIPTION
During a recent deployment of CAMO, more than 50% of clusters failed to upgrade because of `ConstraintsNotSatisfiable` errors. 

We have already swapped this repo over to the `CreateOrUpdate` mode, so this looks to have been caused by a different issue. 

When doing some digging, we found  we're doing upgrading a version that's N-13 versions older, and we suspect OLM isn't allowing the upgrade because we aren't setting `olm.skipRange: '>=0.0.1 <0.1.x-foo'` on resources. This change will result in allowing skip ranges going forward.  