### PR TITLE
Update boilerplate to 7cad75ab

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,9 @@
 aliases:
   srep-functional-team-aurora:
     - abyrne55
+    - AlexSmithGH
     - dakotalongRH
+    - eth1030
     - joshbranham
     - luis-falcon
     - reedcort
@@ -65,7 +67,6 @@ aliases:
     - feichashao
     - samanthajayasinghe
     - xiaoyu74
-    - Dee-6777
     - Tessg22
     - smarthall
   srep-infra-cicd:

--- a/boilerplate/_data/last-boilerplate-commit
+++ b/boilerplate/_data/last-boilerplate-commit
@@ -1,1 +1,1 @@
-e6f4ff66c8446a40a0f350411fe661e1d65b8d1d
+7cad75ab9ae8ed0fefa66b4f1a614f8d1cbcb0eb

--- a/boilerplate/openshift/golang-osd-e2e/update
+++ b/boilerplate/openshift/golang-osd-e2e/update
@@ -21,7 +21,7 @@ OPERATOR_NAME_CAMEL_CASE=${OPERATOR_PROPER_NAME// /}
 
 mkdir -p "${E2E_SUITE_DIRECTORY}"
 
-E2E_SUITE_BUILDER_IMAGE=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.20
+E2E_SUITE_BUILDER_IMAGE=registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.24-openshift-4.21
 if [[ -n ${KONFLUX_BUILDS} ]]; then
 	E2E_SUITE_BUILDER_IMAGE="brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24"
 fi

--- a/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
+++ b/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES
@@ -5,7 +5,9 @@
 aliases:
   srep-functional-team-aurora:
     - abyrne55
+    - AlexSmithGH
     - dakotalongRH
+    - eth1030
     - joshbranham
     - luis-falcon
     - reedcort
@@ -65,7 +67,6 @@ aliases:
     - feichashao
     - samanthajayasinghe
     - xiaoyu74
-    - Dee-6777
     - Tessg22
     - smarthall
   srep-infra-cicd:


### PR DESCRIPTION
## Summary
- Updates boilerplate to commit 7cad75ab
- Adds AlexSmithGH and eth1030 to SREP Aurora team
- Removes Dee-6777 from SREP Daemons team  
- Updates E2E builder image reference from OpenShift 4.20 to 4.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)