### PR TITLE
Stop routing etcdExcessiveDatabaseGrowth to SRE

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -457,9 +457,6 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// Route ClusterOperatorDown for insights to null receiver https://issues.redhat.com/browse/OSD-19800
 		// Also needs to be silenced for FedRAMP until its made available in the environment https://issues.redhat.com/browse/OSD-13685
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterOperatorDown", "name": "insights"}},
-		// Route etcdExcessiveDatabaseGrowth warning level alerts to SRE as critical to aid in reducing incidents related
-		// to customers exceeding etcd's max database size.
-		{Receiver: receiverCritical, Match: map[string]string{"alertname": "etcdExcessiveDatabaseGrowth"}},
 	}
 
 	if !config.IsFedramp() {


### PR DESCRIPTION
This reverts https://github.com/openshift/configure-alertmanager-operator/commit/9e1ebdfb2430f21ed1501af64cc841bb4d26c1e3 which is no longer now that we have better default alerting merged into OpenShift via https://issues.redhat.com/browse/SREP-1244