### PR TITLE
Add missing PKO migration resources: OLM cleanup, Prometheus RBAC, and FEDRAMP support

### DIFF
--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -32,10 +32,39 @@ rules:
     resources:
       - clusterserviceversions
       - subscriptions
+      - catalogsources
     verbs:
       - list
       - get
       - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - configure-alertmanager-operator
+    verbs:
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: olm-cleanup-configure-alertmanager-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # Permission to delete CAMO-specific ClusterRoleBinding
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    resourceNames:
+      - configure-alertmanager-operator-prom
+    verbs:
+      - get
       - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -49,6 +78,22 @@ metadata:
 roleRef:
   kind: Role
   name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: olm-cleanup-configure-alertmanager-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: ClusterRole
+  name: olm-cleanup-configure-alertmanager-operator
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
@@ -82,15 +127,27 @@ spec:
             - |
               #!/bin/sh
               set -euxo pipefail
-              # CUSTOMIZE: Update the label selector for your operator
-              # Example pattern: operators.coreos.com/OPERATOR_NAME.NAMESPACE
+
+              # Clean up OLM resources for configure-alertmanager-operator
+              # Use fully-qualified resource names (subscription.operators.coreos.com, catalogsource.operators.coreos.com)
+              # to explicitly target the OLM API group and avoid ambiguity
+
+              # Delete ClusterServiceVersion
               oc -n openshift-monitoring delete csv -l "operators.coreos.com/configure-alertmanager-operator.openshift-monitoring" || true
-              
-              # CUSTOMIZE: Add any additional cleanup logic here
-              # Examples:
-              # - Delete subscriptions
-              # - Delete operator groups
-              # - Clean up custom resources
+
+              # Delete Subscription
+              oc -n openshift-monitoring delete subscription.operators.coreos.com configure-alertmanager-operator || true
+
+              # Delete CatalogSource
+              oc -n openshift-monitoring delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry || true
+
+              # Delete CAMO-specific ClusterRoleBinding (allows PKO to recreate it)
+              oc delete clusterrolebinding configure-alertmanager-operator-prom || true
+
+              # Delete CAMO ServiceAccount (allows PKO to recreate it without Hive labels)
+              oc -n openshift-monitoring delete serviceaccount configure-alertmanager-operator || true
+
+              # Note: OperatorGroup not deleted - CAMO uses existing openshift-monitoring OperatorGroup
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/ClusterRole-configure-alertmanager-operator-edit.yaml.gotmpl
+++ b/deploy_pko/ClusterRole-configure-alertmanager-operator-edit.yaml.gotmpl
@@ -7,7 +7,6 @@ metadata:
 rules:
 - apiGroups:
   - ''
-  attributeRestrictions: null
   resources:
   - secrets
   - configmaps

--- a/deploy_pko/ClusterRole-configure-alertmanager-operator-view.yaml.gotmpl
+++ b/deploy_pko/ClusterRole-configure-alertmanager-operator-view.yaml.gotmpl
@@ -14,7 +14,6 @@ rules:
   - list
 - apiGroups:
   - config.openshift.io
-  attributeRestrictions: null
   resources:
   - clusterversions
   verbs:

--- a/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
+++ b/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
@@ -1,14 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: configure-alertmanager-operator-edit
-  namespace: openshift-monitoring
+  name: configure-alertmanager-operator-prom
   annotations:
     package-operator.run/phase: rbac
 roleRef:
-  kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: configure-alertmanager-operator-edit
+  kind: ClusterRole
+  name: cluster-monitoring-view
 subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator

--- a/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-view.yaml.gotmpl
+++ b/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-view.yaml.gotmpl
@@ -1,4 +1,4 @@
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: configure-alertmanager-operator-view

--- a/deploy_pko/Deployment-configure-alertmanager-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-configure-alertmanager-operator.yaml.gotmpl
@@ -49,7 +49,7 @@ spec:
         - name: OPERATOR_NAME
           value: configure-alertmanager-operator
         - name: FEDRAMP
-          value: 'false'
+          value: '{{ .config.fedramp }}'
         resources:
           limits:
             cpu: 200m

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -32,5 +32,9 @@ spec:
         image:
           description: Operator image to deploy
           type: string
-          default: None
-        type: object
+          default: ""
+        fedramp:
+          description: FedRAMP mode flag
+          type: string
+          default: "false"
+      type: object

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -16,6 +16,9 @@ parameters:
   - name: REPO_NAME
     value: configure-alertmanager-operator
     required: true
+  - name: FEDRAMP
+    value: "false"
+    required: false
 metadata:
   name: selectorsyncset-template
 objects:
@@ -43,3 +46,4 @@ objects:
             image: ${PKO_IMAGE}:${IMAGE_TAG}
             config:
               image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
+              fedramp: ${FEDRAMP}


### PR DESCRIPTION
## Summary

Adds missing resources for PKO migration and fixes API compatibility issues discovered during live testing on OCP 4.21.5.

## Changes

### Missing PKO Migration Resources

**OLM Cleanup Job:**
- Add `catalogsources` and `serviceaccounts` to RBAC Role permissions
- Add ClusterRole + ClusterRoleBinding for deleting cluster-scoped resources
- Add Subscription cleanup: `subscription.operators.coreos.com configure-alertmanager-operator`
- Add CatalogSource cleanup: `catalogsource.operators.coreos.com configure-alertmanager-operator-registry`
- Add ClusterRoleBinding cleanup: `configure-alertmanager-operator-prom` (prevents PKO adoption conflicts)
- Add ServiceAccount cleanup: `configure-alertmanager-operator` (allows PKO to recreate without Hive labels)
- Use fully-qualified resource names to explicitly target the OLM API group

**Missing RBAC Resource:**
- Add `ClusterRoleBinding-configure-alertmanager-operator-prom.yaml`
- Binds operator ServiceAccount to `cluster-monitoring-view` ClusterRole
- Required for Prometheus queries in cluster readiness check (`pkg/readiness/cluster_ready.go`)
- Without this binding, operator fails with 403 errors and enters infinite retry loop

**FEDRAMP Support:**
- Add `FEDRAMP` parameter to `hack/pko/clusterpackage.yaml` (default: "false")
- Add `fedramp` field to PackageManifest schema in `deploy_pko/manifest.yaml`
- Update Deployment to use templated `{{ .config.fedramp }}` instead of hardcoded value
- Enables FEDRAMP mode configuration for FedRAMP-compliant deployments

### API Compatibility Fixes

**Deprecated Kubernetes Fields (K8s 1.17+):**
- Remove `attributeRestrictions: null` from ClusterRole templates
- This field was deprecated in Kubernetes 1.17 and causes PKO validation errors
- OLM deployments didn't fail because the field existed before deprecation

**ClusterRoleBinding API Version:**
- Change from deprecated `authorization.openshift.io/v1` to `rbac.authorization.k8s.io/v1`
- Fixes PKO error: `watch is not supported on resources of kind "clusterrolebindings.authorization.openshift.io"`

**PackageManifest Schema Validation:**
- Fix `manifest.yaml`: change `image.default` from `None` to `""` (empty string)
- PKO validation requires OpenAPIV3Schema default values to match their declared type
- The unquoted `None` becomes null/nil which fails validation for string type fields

## What Gets Cleaned Up

- **ClusterServiceVersion** (existing) - via label selector
- **Subscription** (new) - `configure-alertmanager-operator`
- **CatalogSource** (new) - `configure-alertmanager-operator-registry`
- **ClusterRoleBinding** (new) - `configure-alertmanager-operator-prom`
- **ServiceAccount** (new) - `configure-alertmanager-operator`
- **OperatorGroup** - not deleted (CAMO uses existing `openshift-monitoring` OperatorGroup)

## Testing

All changes tested on live ROSA cluster (OCP 4.21.5):
- ✅ PKO cleanup job successfully removes all OLM resources
- ✅ PKO deployment succeeds with no validation errors
- ✅ All operator resources created without adoption conflicts
- ✅ Operator pod deploys successfully

## Context

**OLM Cleanup:** Implements the TODO comments that were in the original PKO cleanup template. The cleanup job runs on managed OSD clusters (where CAMO is deployed via SelectorSyncSet) and removes OLM resources after the PKO migration.

**Prometheus ClusterRoleBinding:** In March 2021, commit 994845d8 ([OSD-6646](https://redhat.atlassian.net/browse/OSD-6646)) moved the `configure-alertmanager-operator-prom` ClusterRoleBinding from operator manifests into the OLM SelectorSyncSet as a workaround because OLM cannot include ClusterRoleBindings in CSV bundles. PKO has no such limitation, so this PR returns the ClusterRoleBinding to its proper location in the operator package manifests (`deploy_pko/`).

**FEDRAMP Configuration:** The OLM deployment had a FEDRAMP template parameter passed via Subscription config.env. The PKO migration initially hardcoded this to "false". This change restores configuration capability for FedRAMP-compliant environments. The operator uses this flag to modify alert routing and redact sensitive information from PagerDuty alerts.

**API Compatibility Issues:** During PKO deployment testing, we discovered that `make pko-migrate` copied deprecated fields from OLM's `deploy/01_role.yaml` without stripping them. These fields worked in OLM but fail PKO's stricter validation.

Related: #495 (phase reordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
