### PR TITLE
Add direct ClusterPackage template for hive deployment

### DIFF
--- a/hack/pko/clusterpackage-direct.yaml
+++ b/hack/pko/clusterpackage-direct.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Template
+parameters:
+  - name: CHANNEL
+    required: false
+  - name: OPERATOR_IMAGE
+    required: true
+  - name: PKO_IMAGE
+    required: true
+  - name: IMAGE_TAG
+    required: true
+  - name: IMAGE_DIGEST
+    required: true
+  - name: NAMESPACE
+    value: openshift-monitoring
+  - name: REPO_NAME
+    value: configure-alertmanager-operator
+    required: true
+  - name: FEDRAMP
+    value: "false"
+    required: false
+metadata:
+  name: clusterpackage-direct-template
+objects:
+  - apiVersion: package-operator.run/v1alpha1
+    kind: ClusterPackage
+    metadata:
+      name: "${REPO_NAME}"
+      annotations:
+        package-operator.run/collision-protection: IfNoController
+    spec:
+      image: ${PKO_IMAGE}:${IMAGE_TAG}
+      config:
+        image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
+        fedramp: ${FEDRAMP}


### PR DESCRIPTION
## What
Adds new direct ClusterPackage template for deploying CAMO directly on hive clusters (without SelectorSyncSet wrapper).

## Why
- Enable dual-deployment: CAMO will run on both managed clusters (via SSS) AND hive clusters (direct)
- Required for Phase 3b: deploying CAMO to hive infrastructure clusters
- Follows pattern from operators like AAO, DMS that deploy directly to hive

## Changes
- **New file**: `hack/pko/clusterpackage-direct.yaml`
  - Direct ClusterPackage template (no SSS wrapper)
  - Simpler than current SSS template
  - Based on aws-account-operator pattern

## Related
- App-interface MR (pending): Will add second resourceTemplate using this new template
- [SREP-3848](https://redhat.atlassian.net/browse/SREP-3848): Migrate CAMO from OLM to PKO

[SREP-3848]: https://redhat.atlassian.net/browse/SREP-3848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ