### PR TITLE
Add PKO Namespace resource with collision protection

### DIFF
--- a/deploy_pko/Namespace-openshift-monitoring.yaml
+++ b/deploy_pko/Namespace-openshift-monitoring.yaml
@@ -1,0 +1,15 @@
+---
+# This Namespace resource ensures the operator namespace exists
+# Uses collision-protection to prevent conflicts with existing namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-monitoring
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+  annotations:
+    package-operator.run/phase: namespace
+    package-operator.run/collision-protection: IfNoController


### PR DESCRIPTION
## Summary

Adds a dedicated Namespace resource to the PKO deployment manifests to ensure collision-free installation during direct ClusterPackage deployments (e.g., to hive clusters).

## Changes

- **New file**: `deploy_pko/Namespace-openshift-monitoring.yaml`
  - Creates the `openshift-monitoring` namespace
  - Uses `package-operator.run/phase: namespace` to ensure proper ordering
  - Uses `package-operator.run/collision-protection: IfNoController` for safe migration

## Why this is needed

With the addition of direct ClusterPackage deployment to hive clusters (PR #499), we need to ensure the operator namespace exists before PKO attempts to install resources into it.

The `IfNoController` collision protection prevents conflicts when:
- The namespace already exists (managed by OLM during migration)
- The namespace is created by another controller
- PKO is re-deployed or updated

## Phase ordering

The PKO manifest defines phases in this order (from `manifest.yaml`):
1. `crds`
2. **`namespace`** ← This resource runs here
3. `cleanup-rbac`
4. `cleanup-deploy`
5. `rbac`
6. `deploy`

This ensures the namespace exists before cleanup or deployment phases attempt to use it.

## Follows established pattern

This approach matches the pattern used by route-monitor-operator's PKO deployment, where namespace creation is handled as a dedicated resource with collision protection.

## Test plan

- [ ] Verify PKO package builds successfully with new manifest
- [ ] Test deployment to integration hive cluster
- [ ] Verify namespace is created with correct labels
- [ ] Verify collision protection works during OLM→PKO migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)