### PR TITLE
Add terminationMessagePolicy for OCP 4.21 conformance

### DIFF
--- a/deploy/04_operator.yaml
+++ b/deploy/04_operator.yaml
@@ -51,3 +51,4 @@ spec:
             limits:
               cpu: "200m"
               memory: "1Gi"
+          terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy_pko/Deployment-configure-alertmanager-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-configure-alertmanager-operator.yaml.gotmpl
@@ -54,3 +54,4 @@ spec:
           limits:
             cpu: 200m
             memory: 1Gi
+        terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## Summary

- Adds `terminationMessagePolicy: FallbackToLogsOnError` to the operator container spec in both OLM (`deploy/`) and PKO (`deploy_pko/`) deployment manifests

The `required-scc` annotation was already present in both files. The `terminationMessagePolicy` ensures container termination messages capture log output on error, which is required for OCP 4.21 conformance.

## Test plan

- [ ] Verify YAML is valid and properly indented
- [ ] Deploy to integration and confirm operator starts correctly
- [ ] Confirm `terminationMessagePolicy` appears in pod spec via `oc get pod -o yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations to enhance error message diagnostics during container termination events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->