### PR TITLE
SREP-4581: Fix invalid Prometheus label route-to-cad in configure-ale…

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -120,7 +120,7 @@ const (
 	defaultReceiver = receiverNull
 
 	// alert label used to identify CAD alerts to be routed to event-based automation service
-	routeCADLabel      = "route-to-cad"
+	routeCADLabel      = "route_to_cad"
 	routeCADLabelValue = "true"
 
 	// global config for PagerdutyURL

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -250,7 +250,7 @@ func verifyPagerdutyReceivers(t *testing.T, key string, proxy string, receivers 
 
 func verifyCADPagerdutyRoute(t *testing.T, route *alertmanager.Route) {
 	assertEquals(t, receiverCADPagerduty, route.Receiver, "Receiver Name")
-	assertEquals(t, routeCADLabelValue, route.Match[routeCADLabel], "Match route-to-cad label")
+	assertEquals(t, routeCADLabelValue, route.Match[routeCADLabel], "Match route_to_cad label")
 }
 
 func verifyCADPagerdutyReceivers(t *testing.T, key string, proxy string, receivers []*alertmanager.Receiver) {


### PR DESCRIPTION
…rtmanager-operator

- Rename label `route-to-cad` to `route_to_cad` — hyphens are invalid in Prometheus label names on OCP ≤4.18 (Prometheus v2)                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
  Fixes: https://redhat.atlassian.net/browse/SREP-4581                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
  Related rollbacks:                                                                                                                                                                                                                                                                                                
  - https://github.com/openshift/managed-cluster-config/pull/2687                                                                                                                                                                                                                                                   
  - https://gitlab.cee.redhat.com/service/dynatrace-config/-/merge_requests/1272   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Renamed the CAD routing label from "route-to-cad" to "route_to_cad", and updated PagerDuty Alertmanager routing and related tests to use the new label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->