### PR TITLE
Add PKO template test contexts and cleanup Job TTL

### DIFF
--- a/deploy_pko/.dockerignore
+++ b/deploy_pko/.dockerignore
@@ -1,0 +1,1 @@
+.test-fixtures

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -138,11 +138,11 @@ spec:
               ERRORS=""
               NS="openshift-monitoring"
 
-              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete CSV. "
-
               oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete Subscription. "
+
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
 
               oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -47,6 +47,12 @@ rules:
     verbs:
       - get
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -129,26 +135,41 @@ spec:
               #!/bin/sh
               set -euxo pipefail
 
-              # Clean up OLM resources for configure-alertmanager-operator
-              # Use fully-qualified resource names (subscription.operators.coreos.com, catalogsource.operators.coreos.com)
-              # to explicitly target the OLM API group and avoid ambiguity
+              ERRORS=""
+              NS="openshift-monitoring"
 
-              # Delete ClusterServiceVersion
-              oc -n openshift-monitoring delete csv -l "operators.coreos.com/configure-alertmanager-operator.openshift-monitoring" || true
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
 
-              # Delete Subscription
-              oc -n openshift-monitoring delete subscription.operators.coreos.com configure-alertmanager-operator || true
+              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete Subscription. "
 
-              # Delete CatalogSource
-              oc -n openshift-monitoring delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry || true
+              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
-              # Delete CAMO-specific ClusterRoleBinding (allows PKO to recreate it)
-              oc delete clusterrolebinding configure-alertmanager-operator-prom || true
+              oc delete clusterrolebinding configure-alertmanager-operator-prom --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete ClusterRoleBinding. "
 
-              # Delete CAMO ServiceAccount (allows PKO to recreate it without Hive labels)
-              oc -n openshift-monitoring delete serviceaccount configure-alertmanager-operator || true
+              oc -n "$NS" delete serviceaccount configure-alertmanager-operator --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
-              # Note: OperatorGroup not deleted - CAMO uses existing openshift-monitoring OperatorGroup
+              if [ -n "$ERRORS" ]; then
+                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
+                oc create -f - <<EVENTEOF || true
+              apiVersion: v1
+              kind: Event
+              metadata:
+                generateName: olm-cleanup-warning-
+                namespace: ${NS}
+              involvedObject:
+                apiVersion: v1
+                kind: Namespace
+                name: ${NS}
+              reason: OLMCleanupErrors
+              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              type: Warning
+              EVENTEOF
+              fi
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -1,0 +1,155 @@
+---
+# This Job cleans up old OLM resources after migrating to PKO
+# IMPORTANT: Review and customize this template before deploying!
+# 
+# Things to customize:
+# 1. Adjust the namespace if needed
+# 2. Modify resource filters (CSV names, labels, etc.)
+# 3. Review RBAC permissions
+# 4. Update the cleanup logic for your specific operator
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - catalogsources
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - configure-alertmanager-operator
+    verbs:
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: olm-cleanup-configure-alertmanager-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # Permission to delete CAMO-specific ClusterRoleBinding
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    resourceNames:
+      - configure-alertmanager-operator-prom
+    verbs:
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: olm-cleanup-configure-alertmanager-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: ClusterRole
+  name: olm-cleanup-configure-alertmanager-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: openshift-monitoring
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+
+              # Clean up OLM resources for configure-alertmanager-operator
+              # Use fully-qualified resource names (subscription.operators.coreos.com, catalogsource.operators.coreos.com)
+              # to explicitly target the OLM API group and avoid ambiguity
+
+              # Delete ClusterServiceVersion
+              oc -n openshift-monitoring delete csv -l "operators.coreos.com/configure-alertmanager-operator.openshift-monitoring" || true
+
+              # Delete Subscription
+              oc -n openshift-monitoring delete subscription.operators.coreos.com configure-alertmanager-operator || true
+
+              # Delete CatalogSource
+              oc -n openshift-monitoring delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry || true
+
+              # Delete CAMO-specific ClusterRoleBinding (allows PKO to recreate it)
+              oc delete clusterrolebinding configure-alertmanager-operator-prom || true
+
+              # Delete CAMO ServiceAccount (allows PKO to recreate it without Hive labels)
+              oc -n openshift-monitoring delete serviceaccount configure-alertmanager-operator || true
+
+              # Note: OperatorGroup not deleted - CAMO uses existing openshift-monitoring OperatorGroup
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -154,8 +154,8 @@ spec:
                 || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
               if [ -n "$ERRORS" ]; then
-                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
-                oc create -f - <<EVENTEOF || true
+                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2
+                oc create -f - <<EVENTEOF || echo "Failed to create warning event. See script output" >&2
               apiVersion: v1
               kind: Event
               metadata:

--- a/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-edit.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: configure-alertmanager-operator-edit
+  annotations:
+    package-operator.run/phase: rbac
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-view.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: configure-alertmanager-operator-view
+  annotations:
+    package-operator.run/phase: rbac
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: configure-alertmanager-operator-edit
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: configure-alertmanager-operator-edit
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: configure-alertmanager-operator-edit
-  namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
 roleRef:

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: configure-alertmanager-operator-prom
+  annotations:
+    package-operator.run/phase: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: configure-alertmanager-operator-view
+  annotations:
+    package-operator.run/phase: rbac
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: configure-alertmanager-operator-view
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/default/Deployment-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/Deployment-configure-alertmanager-operator.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: configure-alertmanager-operator
+  template:
+    metadata:
+      labels:
+        name: configure-alertmanager-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: configure-alertmanager-operator
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      containers:
+      - name: configure-alertmanager-operator
+        image: 'quay.io/example/configure-alertmanager-operator:test'
+        command:
+        - configure-alertmanager-operator
+        imagePullPolicy: Always
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: configure-alertmanager-operator
+        - name: FEDRAMP
+          value: 'false'
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1Gi

--- a/deploy_pko/.test-fixtures/default/Role-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/Role-configure-alertmanager-operator.yaml
@@ -1,0 +1,50 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - configure-alertmanager-operator
+  verbs:
+  - update

--- a/deploy_pko/.test-fixtures/default/RoleBinding-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/RoleBinding-configure-alertmanager-operator.yaml
@@ -8,6 +8,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator
+  namespace: openshift-monitoring
 roleRef:
   kind: Role
   name: configure-alertmanager-operator

--- a/deploy_pko/.test-fixtures/default/RoleBinding-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/RoleBinding-configure-alertmanager-operator.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+roleRef:
+  kind: Role
+  name: configure-alertmanager-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/default/ServiceAccount-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ServiceAccount-configure-alertmanager-operator.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -138,11 +138,11 @@ spec:
               ERRORS=""
               NS="openshift-monitoring"
 
-              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete CSV. "
-
               oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete Subscription. "
+
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
 
               oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -47,6 +47,12 @@ rules:
     verbs:
       - get
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -129,26 +135,41 @@ spec:
               #!/bin/sh
               set -euxo pipefail
 
-              # Clean up OLM resources for configure-alertmanager-operator
-              # Use fully-qualified resource names (subscription.operators.coreos.com, catalogsource.operators.coreos.com)
-              # to explicitly target the OLM API group and avoid ambiguity
+              ERRORS=""
+              NS="openshift-monitoring"
 
-              # Delete ClusterServiceVersion
-              oc -n openshift-monitoring delete csv -l "operators.coreos.com/configure-alertmanager-operator.openshift-monitoring" || true
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
 
-              # Delete Subscription
-              oc -n openshift-monitoring delete subscription.operators.coreos.com configure-alertmanager-operator || true
+              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete Subscription. "
 
-              # Delete CatalogSource
-              oc -n openshift-monitoring delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry || true
+              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
-              # Delete CAMO-specific ClusterRoleBinding (allows PKO to recreate it)
-              oc delete clusterrolebinding configure-alertmanager-operator-prom || true
+              oc delete clusterrolebinding configure-alertmanager-operator-prom --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete ClusterRoleBinding. "
 
-              # Delete CAMO ServiceAccount (allows PKO to recreate it without Hive labels)
-              oc -n openshift-monitoring delete serviceaccount configure-alertmanager-operator || true
+              oc -n "$NS" delete serviceaccount configure-alertmanager-operator --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
-              # Note: OperatorGroup not deleted - CAMO uses existing openshift-monitoring OperatorGroup
+              if [ -n "$ERRORS" ]; then
+                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
+                oc create -f - <<EVENTEOF || true
+              apiVersion: v1
+              kind: Event
+              metadata:
+                generateName: olm-cleanup-warning-
+                namespace: ${NS}
+              involvedObject:
+                apiVersion: v1
+                kind: Namespace
+                name: ${NS}
+              reason: OLMCleanupErrors
+              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              type: Warning
+              EVENTEOF
+              fi
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -1,0 +1,155 @@
+---
+# This Job cleans up old OLM resources after migrating to PKO
+# IMPORTANT: Review and customize this template before deploying!
+# 
+# Things to customize:
+# 1. Adjust the namespace if needed
+# 2. Modify resource filters (CSV names, labels, etc.)
+# 3. Review RBAC permissions
+# 4. Update the cleanup logic for your specific operator
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # CUSTOMIZE: Adjust permissions as needed for your cleanup tasks
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - catalogsources
+    verbs:
+      - list
+      - get
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - configure-alertmanager-operator
+    verbs:
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: olm-cleanup-configure-alertmanager-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+rules:
+  # Permission to delete CAMO-specific ClusterRoleBinding
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    resourceNames:
+      - configure-alertmanager-operator-prom
+    verbs:
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: Role
+  name: olm-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: olm-cleanup-configure-alertmanager-operator
+  annotations:
+    package-operator.run/phase: cleanup-rbac
+    package-operator.run/collision-protection: IfNoController
+roleRef:
+  kind: ClusterRole
+  name: olm-cleanup-configure-alertmanager-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: olm-cleanup
+    namespace: openshift-monitoring
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: olm-cleanup
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: cleanup-deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: olm-cleanup
+      priorityClassName: openshift-user-critical
+      restartPolicy: Never
+      containers:
+        - name: delete-csv
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          imagePullPolicy: Always
+          command:
+            - sh
+            - -c
+            - |
+              #!/bin/sh
+              set -euxo pipefail
+
+              # Clean up OLM resources for configure-alertmanager-operator
+              # Use fully-qualified resource names (subscription.operators.coreos.com, catalogsource.operators.coreos.com)
+              # to explicitly target the OLM API group and avoid ambiguity
+
+              # Delete ClusterServiceVersion
+              oc -n openshift-monitoring delete csv -l "operators.coreos.com/configure-alertmanager-operator.openshift-monitoring" || true
+
+              # Delete Subscription
+              oc -n openshift-monitoring delete subscription.operators.coreos.com configure-alertmanager-operator || true
+
+              # Delete CatalogSource
+              oc -n openshift-monitoring delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry || true
+
+              # Delete CAMO-specific ClusterRoleBinding (allows PKO to recreate it)
+              oc delete clusterrolebinding configure-alertmanager-operator-prom || true
+
+              # Delete CAMO ServiceAccount (allows PKO to recreate it without Hive labels)
+              oc -n openshift-monitoring delete serviceaccount configure-alertmanager-operator || true
+
+              # Note: OperatorGroup not deleted - CAMO uses existing openshift-monitoring OperatorGroup
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -154,8 +154,8 @@ spec:
                 || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
               if [ -n "$ERRORS" ]; then
-                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
-                oc create -f - <<EVENTEOF || true
+                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2
+                oc create -f - <<EVENTEOF || echo "Failed to create warning event. See script output" >&2
               apiVersion: v1
               kind: Event
               metadata:

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-edit.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: configure-alertmanager-operator-edit
+  annotations:
+    package-operator.run/phase: rbac
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-view.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: configure-alertmanager-operator-view
+  annotations:
+    package-operator.run/phase: rbac
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: configure-alertmanager-operator-edit
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: configure-alertmanager-operator-edit
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: configure-alertmanager-operator-edit
-  namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
 roleRef:

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: configure-alertmanager-operator-prom
+  annotations:
+    package-operator.run/phase: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: configure-alertmanager-operator-view
+  annotations:
+    package-operator.run/phase: rbac
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: configure-alertmanager-operator-view
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/Deployment-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Deployment-configure-alertmanager-operator.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: deploy
+    package-operator.run/collision-protection: IfNoController
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: configure-alertmanager-operator
+  template:
+    metadata:
+      labels:
+        name: configure-alertmanager-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
+    spec:
+      serviceAccountName: configure-alertmanager-operator
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      containers:
+      - name: configure-alertmanager-operator
+        image: 'quay.io/example/configure-alertmanager-operator:test'
+        command:
+        - configure-alertmanager-operator
+        imagePullPolicy: Always
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: configure-alertmanager-operator
+        - name: FEDRAMP
+          value: 'true'
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1Gi

--- a/deploy_pko/.test-fixtures/fedramp/Role-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Role-configure-alertmanager-operator.yaml
@@ -1,0 +1,50 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - configure-alertmanager-operator
+  verbs:
+  - update

--- a/deploy_pko/.test-fixtures/fedramp/RoleBinding-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/RoleBinding-configure-alertmanager-operator.yaml
@@ -8,6 +8,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator
+  namespace: openshift-monitoring
 roleRef:
   kind: Role
   name: configure-alertmanager-operator

--- a/deploy_pko/.test-fixtures/fedramp/RoleBinding-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/RoleBinding-configure-alertmanager-operator.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring
+  annotations:
+    package-operator.run/phase: rbac
+subjects:
+- kind: ServiceAccount
+  name: configure-alertmanager-operator
+roleRef:
+  kind: Role
+  name: configure-alertmanager-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/fedramp/ServiceAccount-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ServiceAccount-configure-alertmanager-operator.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    package-operator.run/phase: rbac
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -138,11 +138,11 @@ spec:
               ERRORS=""
               NS="openshift-monitoring"
 
-              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete CSV. "
-
               oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete Subscription. "
+
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
 
               oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -47,6 +47,12 @@ rules:
     verbs:
       - get
       - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -129,26 +135,41 @@ spec:
               #!/bin/sh
               set -euxo pipefail
 
-              # Clean up OLM resources for configure-alertmanager-operator
-              # Use fully-qualified resource names (subscription.operators.coreos.com, catalogsource.operators.coreos.com)
-              # to explicitly target the OLM API group and avoid ambiguity
+              ERRORS=""
+              NS="openshift-monitoring"
 
-              # Delete ClusterServiceVersion
-              oc -n openshift-monitoring delete csv -l "operators.coreos.com/configure-alertmanager-operator.openshift-monitoring" || true
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CSV. "
 
-              # Delete Subscription
-              oc -n openshift-monitoring delete subscription.operators.coreos.com configure-alertmanager-operator || true
+              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete Subscription. "
 
-              # Delete CatalogSource
-              oc -n openshift-monitoring delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry || true
+              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
-              # Delete CAMO-specific ClusterRoleBinding (allows PKO to recreate it)
-              oc delete clusterrolebinding configure-alertmanager-operator-prom || true
+              oc delete clusterrolebinding configure-alertmanager-operator-prom --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete ClusterRoleBinding. "
 
-              # Delete CAMO ServiceAccount (allows PKO to recreate it without Hive labels)
-              oc -n openshift-monitoring delete serviceaccount configure-alertmanager-operator || true
+              oc -n "$NS" delete serviceaccount configure-alertmanager-operator --ignore-not-found=true \
+                || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
-              # Note: OperatorGroup not deleted - CAMO uses existing openshift-monitoring OperatorGroup
+              if [ -n "$ERRORS" ]; then
+                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
+                oc create -f - <<EVENTEOF || true
+              apiVersion: v1
+              kind: Event
+              metadata:
+                generateName: olm-cleanup-warning-
+                namespace: ${NS}
+              involvedObject:
+                apiVersion: v1
+                kind: Namespace
+                name: ${NS}
+              reason: OLMCleanupErrors
+              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              type: Warning
+              EVENTEOF
+              fi
           resources:
             requests:
               cpu: 100m

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -154,8 +154,8 @@ spec:
                 || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
               if [ -n "$ERRORS" ]; then
-                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}"
-                oc create -f - <<EVENTEOF || true
+                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2
+                oc create -f - <<EVENTEOF || echo "Failed to create warning event. See script output" >&2
               apiVersion: v1
               kind: Event
               metadata:

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -109,6 +109,7 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
+  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml.gotmpl
+++ b/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml.gotmpl
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: configure-alertmanager-operator-edit
-  namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
 roleRef:

--- a/deploy_pko/RoleBinding-configure-alertmanager-operator.yaml.gotmpl
+++ b/deploy_pko/RoleBinding-configure-alertmanager-operator.yaml.gotmpl
@@ -8,6 +8,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator
+  namespace: openshift-monitoring
 roleRef:
   kind: Role
   name: configure-alertmanager-operator

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -38,3 +38,23 @@ spec:
           type: string
           default: "false"
       type: object
+test:
+  template:
+  - name: default
+    context:
+      package:
+        metadata:
+          name: configure-alertmanager-operator
+          namespace: openshift-monitoring
+      config:
+        image: "quay.io/example/configure-alertmanager-operator:test"
+        fedramp: "false"
+  - name: fedramp
+    context:
+      package:
+        metadata:
+          name: configure-alertmanager-operator
+          namespace: openshift-monitoring
+      config:
+        image: "quay.io/example/configure-alertmanager-operator:test"
+        fedramp: "true"


### PR DESCRIPTION
## Summary
- Add default and fedramp test contexts to `manifest.yaml` so CI validates template rendering (not just schema checks)
- Add `ttlSecondsAfterFinished: 100` to the OLM cleanup Job to prevent Job immutability errors during PKO-to-PKO upgrades
- Generate and commit test fixtures for both contexts

## Test plan
- [x] `make container-generate-pko-fixtures` generates consistent fixtures
- [x] `validate-pko-fixtures` passes in container (fixtures match rendered output)
- [x] Fedramp fixture differs only in FEDRAMP env var (`false` vs `true`)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment, ServiceAccount, RBAC (Roles/ClusterRoles and Bindings) and a one-shot cleanup Job for the operator.

* **Tests**
  * Added test fixtures and two test templates (default and fedramp) to exercise both configurations.

* **Chores**
  * Excluded test-fixtures from Docker build context.
  * Updated base runtime image tags in build images.
  * Set cleanup Job TTL for automatic post-run garbage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->