### PR TITLE
Update boilerplate: bump ubi-minimal to 9.7-1776833838

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776645941
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776645941
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1776833838
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe


### PR DESCRIPTION
## Summary
- Run `make boilerplate-update` to sync Dockerfile base images with upstream boilerplate pins
- Bumps `ubi-minimal` from `9.7-1776645941` to `9.7-1776833838` in `build/Dockerfile` and `build/Dockerfile.olm-registry`

## Test plan
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)