### PR TITLE
Add terminationMessagePolicy for OCP 4.21 conformance

### DIFF
--- a/deploy/04_operator.yaml
+++ b/deploy/04_operator.yaml
@@ -51,3 +51,4 @@ spec:
             limits:
               cpu: "200m"
               memory: "1Gi"
+          terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy_pko/.test-fixtures/default/Deployment-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/Deployment-configure-alertmanager-operator.yaml
@@ -54,3 +54,4 @@ spec:
           limits:
             cpu: 200m
             memory: 1Gi
+        terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy_pko/.test-fixtures/fedramp/Deployment-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Deployment-configure-alertmanager-operator.yaml
@@ -54,3 +54,4 @@ spec:
           limits:
             cpu: 200m
             memory: 1Gi
+        terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy_pko/Deployment-configure-alertmanager-operator.yaml.gotmpl
+++ b/deploy_pko/Deployment-configure-alertmanager-operator.yaml.gotmpl
@@ -54,3 +54,4 @@ spec:
           limits:
             cpu: 200m
             memory: 1Gi
+        terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
## Summary
- Adds `terminationMessagePolicy: FallbackToLogsOnError` to the operator container spec in both OLM (`deploy/`) and PKO (`deploy_pko/`) deployment manifests
- Regenerates PKO test fixtures to include the new field

Replaces #505 which could not be rebased by the original author.

## Test plan
- [ ] Verify YAML is valid and properly indented
- [ ] CI pipeline passes
- [ ] Confirm `terminationMessagePolicy` appears in pod spec via `oc get pod -o yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pod termination error handling configuration to improve diagnostic logging when normal termination reporting fails, enabling better troubleshooting of pod failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->