### PR TITLE
Fix cleanup Job: remove non-OLM resource deletes causing CrashLoopBackOff

### DIFF
--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -41,37 +41,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - serviceaccounts
-    resourceNames:
-      - configure-alertmanager-operator
-    verbs:
-      - get
-      - delete
-  - apiGroups:
-      - ""
-    resources:
       - events
     verbs:
       - create
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: olm-cleanup-configure-alertmanager-operator
-  annotations:
-    package-operator.run/phase: cleanup-rbac
-    package-operator.run/collision-protection: IfNoController
-rules:
-  # Permission to delete CAMO-specific ClusterRoleBinding
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-    resourceNames:
-      - configure-alertmanager-operator-prom
-    verbs:
-      - get
-      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -84,22 +56,6 @@ metadata:
 roleRef:
   kind: Role
   name: olm-cleanup
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: olm-cleanup
-    namespace: openshift-monitoring
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: olm-cleanup-configure-alertmanager-operator
-  annotations:
-    package-operator.run/phase: cleanup-rbac
-    package-operator.run/collision-protection: IfNoController
-roleRef:
-  kind: ClusterRole
-  name: olm-cleanup-configure-alertmanager-operator
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
@@ -146,12 +102,6 @@ spec:
 
               oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "
-
-              oc delete clusterrolebinding configure-alertmanager-operator-prom --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete ClusterRoleBinding. "
-
-              oc -n "$NS" delete serviceaccount configure-alertmanager-operator --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
               if [ -n "$ERRORS" ]; then
                 echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -41,37 +41,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - serviceaccounts
-    resourceNames:
-      - configure-alertmanager-operator
-    verbs:
-      - get
-      - delete
-  - apiGroups:
-      - ""
-    resources:
       - events
     verbs:
       - create
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: olm-cleanup-configure-alertmanager-operator
-  annotations:
-    package-operator.run/phase: cleanup-rbac
-    package-operator.run/collision-protection: IfNoController
-rules:
-  # Permission to delete CAMO-specific ClusterRoleBinding
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-    resourceNames:
-      - configure-alertmanager-operator-prom
-    verbs:
-      - get
-      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -84,22 +56,6 @@ metadata:
 roleRef:
   kind: Role
   name: olm-cleanup
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: olm-cleanup
-    namespace: openshift-monitoring
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: olm-cleanup-configure-alertmanager-operator
-  annotations:
-    package-operator.run/phase: cleanup-rbac
-    package-operator.run/collision-protection: IfNoController
-roleRef:
-  kind: ClusterRole
-  name: olm-cleanup-configure-alertmanager-operator
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
@@ -146,12 +102,6 @@ spec:
 
               oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "
-
-              oc delete clusterrolebinding configure-alertmanager-operator-prom --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete ClusterRoleBinding. "
-
-              oc -n "$NS" delete serviceaccount configure-alertmanager-operator --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
               if [ -n "$ERRORS" ]; then
                 echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -41,37 +41,9 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - serviceaccounts
-    resourceNames:
-      - configure-alertmanager-operator
-    verbs:
-      - get
-      - delete
-  - apiGroups:
-      - ""
-    resources:
       - events
     verbs:
       - create
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: olm-cleanup-configure-alertmanager-operator
-  annotations:
-    package-operator.run/phase: cleanup-rbac
-    package-operator.run/collision-protection: IfNoController
-rules:
-  # Permission to delete CAMO-specific ClusterRoleBinding
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-    resourceNames:
-      - configure-alertmanager-operator-prom
-    verbs:
-      - get
-      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -84,22 +56,6 @@ metadata:
 roleRef:
   kind: Role
   name: olm-cleanup
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: olm-cleanup
-    namespace: openshift-monitoring
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: olm-cleanup-configure-alertmanager-operator
-  annotations:
-    package-operator.run/phase: cleanup-rbac
-    package-operator.run/collision-protection: IfNoController
-roleRef:
-  kind: ClusterRole
-  name: olm-cleanup-configure-alertmanager-operator
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
@@ -146,12 +102,6 @@ spec:
 
               oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "
-
-              oc delete clusterrolebinding configure-alertmanager-operator-prom --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete ClusterRoleBinding. "
-
-              oc -n "$NS" delete serviceaccount configure-alertmanager-operator --ignore-not-found=true \
-                || ERRORS="${ERRORS}Failed to delete ServiceAccount. "
 
               if [ -n "$ERRORS" ]; then
                 echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2


### PR DESCRIPTION
## Summary
The OLM cleanup Job was deleting the operator's ServiceAccount and ClusterRoleBinding, which are not OLM-specific resources. On fresh PKO clusters (no OLM migration history), this deletes resources that PKO just created in the `rbac` phase, causing the operator to CrashLoopBackOff:

```
ERROR  setup  unable to start manager
  {"error": "failed to determine if *v1.ClusterVersion is namespaced:
   failed to get restmapping: failed to get server groups:
   the server has asked for the client to provide credentials"}
```

### Changes
- Remove `oc delete serviceaccount configure-alertmanager-operator` from cleanup script
- Remove `oc delete clusterrolebinding configure-alertmanager-operator-prom` from cleanup script
- Remove the ClusterRole and ClusterRoleBinding RBAC that was only needed for the CRB delete permission
- Cleanup Job now only deletes OLM-specific resources: Subscription, CSV, CatalogSource

### Root cause
The cleanup Job runs on every PKO deployment (fresh or migration). On fresh clusters, the SA delete succeeds (removing the PKO-created SA), and the operator pod's projected token becomes invalid. The pod crashes before the token can be refreshed.

## Test plan
- [x] Verified against olm-to-pko-migration skill guidance (only OLM resources should be deleted)
- [x] Verified OLM stage cluster: SA has no CSV ownerReference, so deleting it is not needed for OLM cleanup
- [ ] CI pipeline passes
- [ ] Deploy to integration cluster and verify operator starts without CrashLoopBackOff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the cleanup Job by reducing operational scope across all configurations (default, FedRAMP, and production). Removed RBAC permissions and deletion operations for alertmanager operator-related cluster resources. The cleanup process now focuses on essential subscription, CSV, and catalog source management while preserving error-handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->