### PR TITLE
[SREP-3734] Port AlertmanagerInhibitions e2e tests from osde2e

### DIFF
--- a/test/e2e/configure_alertmanager_operator_tests.go
+++ b/test/e2e/configure_alertmanager_operator_tests.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -35,6 +36,7 @@ var _ = Describe("Configure AlertManager Operator", Ordered, func() {
 		client           *resources.Resources
 		dynamicClient    dynamic.Interface
 		prom             *prometheus.Client
+		amClient         *utils.AlertmanagerClient
 		secrets          = []string{"pd-secret", "dms-secret"}
 		serviceAccounts  = []string{"configure-alertmanager-operator"}
 		deploymentMethod string // "olm", "pko", "both", or "unknown"
@@ -59,12 +61,18 @@ var _ = Describe("Configure AlertManager Operator", Ordered, func() {
 		dynamicClient, err = dynamic.NewForConfig(cfg)
 		Expect(err).ShouldNot(HaveOccurred(), "failed to configure Dynamic client")
 
+		kubeClient, err := kubernetes.NewForConfig(cfg)
+		Expect(err).ShouldNot(HaveOccurred(), "failed to create kubernetes client")
+
 		// Create openshift client locally for prometheus client setup
 		k8s, err := openshift.New(GinkgoLogr)
 		Expect(err).ShouldNot(HaveOccurred(), "unable to setup openshift client")
 
 		prom, err = prometheus.New(ctx, k8s)
 		Expect(err).ShouldNot(HaveOccurred(), "unable to setup prometheus client")
+
+		amClient, err = utils.NewAlertmanagerClient(ctx, dynamicClient, kubeClient, cfg)
+		Expect(err).ShouldNot(HaveOccurred(), "unable to setup alertmanager client")
 
 		// Detect deployment method (OLM, PKO, both, or unknown)
 		deploymentMethod = detectDeploymentMethod(ctx, dynamicClient, namespace, operatorName)
@@ -1349,6 +1357,64 @@ Alerts from hosted control plane namespaces will be routed correctly.
 				Expect(utils.RouteTreeHasMatch(cfg.Route, "send_managed_notification", "true")).To(BeTrue(),
 					"route tree should have match for send_managed_notification=true when OCM Agent is configured")
 			}
+		})
+	})
+
+	Describe("Alertmanager inhibition behavior", func() {
+		It("ClusterOperatorDegraded inhibits ClusterOperatorDown via synthetic alerts", func(ctx context.Context) {
+			sourceAlert := utils.AlertmanagerV2PostAlert{
+				Labels: map[string]string{
+					"alertname": "ClusterOperatorDegraded",
+					"name":      "camo-inhibit-test",
+					"namespace": "camo-inhibit-test",
+					"severity":  "critical",
+				},
+				Annotations: map[string]string{
+					"summary": "Synthetic alert for CAMO inhibition test",
+				},
+			}
+			targetAlert := utils.AlertmanagerV2PostAlert{
+				Labels: map[string]string{
+					"alertname": "ClusterOperatorDown",
+					"name":      "camo-inhibit-test",
+					"namespace": "camo-inhibit-test",
+					"severity":  "critical",
+				},
+				Annotations: map[string]string{
+					"summary": "Synthetic alert for CAMO inhibition test",
+				},
+			}
+
+			DeferCleanup(func(ctx context.Context) {
+				_ = amClient.ResolveAlerts(ctx, []utils.AlertmanagerV2PostAlert{sourceAlert, targetAlert})
+			})
+
+			ginkgo.By("Injecting synthetic source alert (ClusterOperatorDegraded)")
+			err := amClient.PostAlerts(ctx, []utils.AlertmanagerV2PostAlert{sourceAlert})
+			Expect(err).NotTo(HaveOccurred(), "failed to post source alert")
+
+			ginkgo.By("Injecting synthetic target alert (ClusterOperatorDown)")
+			err = amClient.PostAlerts(ctx, []utils.AlertmanagerV2PostAlert{targetAlert})
+			Expect(err).NotTo(HaveOccurred(), "failed to post target alert")
+
+			ginkgo.By("Verifying ClusterOperatorDown is inhibited via Alertmanager v2 API")
+			Eventually(ctx, func() error {
+				alerts, err := amClient.GetAlertsByName(ctx, "ClusterOperatorDown", "camo-inhibit-test")
+				if err != nil {
+					return fmt.Errorf("failed to query alertmanager: %w", err)
+				}
+				if len(alerts) == 0 {
+					return fmt.Errorf("ClusterOperatorDown not yet present in Alertmanager")
+				}
+				for _, alert := range alerts {
+					if alert.Status.State == "suppressed" {
+						return nil
+					}
+					return fmt.Errorf("ClusterOperatorDown state=%q, expected suppressed", alert.Status.State)
+				}
+				return nil
+			}, 10*time.Second, 1*time.Second).Should(Succeed(),
+				"ClusterOperatorDown should be suppressed by ClusterOperatorDegraded")
 		})
 	})
 

--- a/test/e2e/configure_alertmanager_operator_tests.go
+++ b/test/e2e/configure_alertmanager_operator_tests.go
@@ -1407,7 +1407,7 @@ Alerts from hosted control plane namespaces will be routed correctly.
 					return fmt.Errorf("ClusterOperatorDown not yet present in Alertmanager")
 				}
 				for _, alert := range alerts {
-					if alert.Status.State == "suppressed" {
+					if alert.Status.State == "suppressed" && len(alert.Status.InhibitedBy) > 0 {
 						return nil
 					}
 					return fmt.Errorf("ClusterOperatorDown state=%q, expected suppressed", alert.Status.State)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -518,15 +518,17 @@ func NewAlertmanagerClient(ctx context.Context, dynClient dynamic.Interface, kub
 	}
 
 	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
 		Transport: transport.NewBearerAuthRoundTripper(
 			tokenReq.Status.Token,
 			&http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
-					Timeout:   30 * time.Second,
+					Timeout:   5 * time.Second,
 					KeepAlive: 30 * time.Second,
 				}).DialContext,
-				TLSHandshakeTimeout: 10 * time.Second,
+				TLSHandshakeTimeout:   5 * time.Second,
+				ResponseHeaderTimeout: 5 * time.Second,
 				TLSClientConfig: &tls.Config{
 					RootCAs:    roots,
 					ServerName: host,

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -1,16 +1,33 @@
 package utils
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/onsi/gomega"
 	amconfig "github.com/prometheus/alertmanager/config"
 	"gopkg.in/yaml.v2"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 )
 
@@ -405,4 +422,255 @@ func WaitForResourceVersionChange(ctx context.Context, client *resources.Resourc
 		g.Expect(rv).ShouldNot(gomega.Equal(previousVersion),
 			"alertmanager-main resourceVersion should have changed after reconciliation")
 	}
+}
+
+// --- Alertmanager v2 API client ---
+
+// AlertmanagerV2AlertStatus holds the status fields from the Alertmanager v2 API.
+type AlertmanagerV2AlertStatus struct {
+	State       string   `json:"state"`
+	InhibitedBy []string `json:"inhibitedBy"`
+}
+
+// AlertmanagerV2Alert holds the fields from the Alertmanager v2 API needed for e2e testing.
+type AlertmanagerV2Alert struct {
+	Labels map[string]string         `json:"labels"`
+	Status AlertmanagerV2AlertStatus `json:"status"`
+}
+
+// AlertmanagerClient provides access to the Alertmanager v2 API on an OpenShift cluster.
+// GET requests use the external route; POST requests exec into each alertmanager pod
+// directly to avoid load-balancing issues (alerts posted via the API are not gossiped
+// between peers).
+type AlertmanagerClient struct {
+	baseURL    string
+	httpClient *http.Client
+	kubeClient kubernetes.Interface
+	restConfig *rest.Config
+}
+
+// NewAlertmanagerClient creates an AlertmanagerClient by discovering the alertmanager-main
+// route and setting up bearer token authentication with the cluster's router CA.
+func NewAlertmanagerClient(ctx context.Context, dynClient dynamic.Interface, kubeClient kubernetes.Interface, restConfig *rest.Config) (*AlertmanagerClient, error) {
+	routeGVR := schema.GroupVersionResource{
+		Group:    "route.openshift.io",
+		Version:  "v1",
+		Resource: "routes",
+	}
+	route, err := dynClient.Resource(routeGVR).Namespace("openshift-monitoring").Get(ctx, "alertmanager-main", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get alertmanager-main route: %w", err)
+	}
+	ingress, found, err := unstructured.NestedSlice(route.Object, "status", "ingress")
+	if err != nil || !found || len(ingress) == 0 {
+		return nil, fmt.Errorf("alertmanager-main route has no ingress status")
+	}
+	var host string
+	for _, entry := range ingress {
+		entryMap, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		conditions, _, _ := unstructured.NestedSlice(entryMap, "conditions")
+		admitted := false
+		for _, cond := range conditions {
+			condMap, ok := cond.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			condType, _, _ := unstructured.NestedString(condMap, "type")
+			condStatus, _, _ := unstructured.NestedString(condMap, "status")
+			if condType == "Admitted" && condStatus == "True" {
+				admitted = true
+				break
+			}
+		}
+		if !admitted {
+			continue
+		}
+		h, found, _ := unstructured.NestedString(entryMap, "host")
+		if found && h != "" {
+			host = h
+			break
+		}
+	}
+	if host == "" {
+		return nil, fmt.Errorf("alertmanager-main route has no admitted ingress with a host")
+	}
+
+	expirationSeconds := int64(24 * time.Hour / time.Second)
+	tokenReq, err := kubeClient.CoreV1().ServiceAccounts("openshift-monitoring").CreateToken(ctx, "prometheus-k8s",
+		&authenticationv1.TokenRequest{
+			Spec: authenticationv1.TokenRequestSpec{ExpirationSeconds: &expirationSeconds},
+		}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token for prometheus-k8s SA: %w", err)
+	}
+
+	routerCAConfigMap, err := kubeClient.CoreV1().ConfigMaps("openshift-config-managed").Get(ctx, "default-ingress-cert", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get router CA configmap: %w", err)
+	}
+	bundlePEM := []byte(routerCAConfigMap.Data["ca-bundle.crt"])
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(bundlePEM) {
+		return nil, fmt.Errorf("failed to parse any certificates from router CA bundle")
+	}
+
+	httpClient := &http.Client{
+		Transport: transport.NewBearerAuthRoundTripper(
+			tokenReq.Status.Token,
+			&http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout: 10 * time.Second,
+				TLSClientConfig: &tls.Config{
+					RootCAs:    roots,
+					ServerName: host,
+					MinVersion: tls.VersionTLS12,
+				},
+			},
+		),
+	}
+
+	return &AlertmanagerClient{
+		baseURL:    "https://" + host,
+		httpClient: httpClient,
+		kubeClient: kubeClient,
+		restConfig: restConfig,
+	}, nil
+}
+
+// GetAlerts queries the Alertmanager v2 API for alerts matching the given filters.
+// Filters use the Alertmanager filter syntax, e.g. `alertname="ClusterOperatorDown"`.
+func (c *AlertmanagerClient) GetAlerts(ctx context.Context, filters ...string) ([]AlertmanagerV2Alert, error) {
+	u, err := url.Parse(c.baseURL + "/api/v2/alerts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse alertmanager URL: %w", err)
+	}
+	q := u.Query()
+	for _, f := range filters {
+		q.Add("filter", f)
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("alertmanager request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		preview, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("alertmanager returned status %d: %s", resp.StatusCode, string(preview))
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read alertmanager response: %w", err)
+	}
+
+	var alerts []AlertmanagerV2Alert
+	if err := json.Unmarshal(body, &alerts); err != nil {
+		return nil, fmt.Errorf("failed to parse alertmanager response: %w", err)
+	}
+	return alerts, nil
+}
+
+// GetAlertsByName returns alerts from the Alertmanager v2 API matching the given
+// alertname and optional name label.
+func (c *AlertmanagerClient) GetAlertsByName(ctx context.Context, alertname, name string) ([]AlertmanagerV2Alert, error) {
+	filters := []string{fmt.Sprintf(`alertname="%s"`, alertname)}
+	if name != "" {
+		filters = append(filters, fmt.Sprintf(`name="%s"`, name))
+	}
+	return c.GetAlerts(ctx, filters...)
+}
+
+// AlertmanagerV2PostAlert is the payload for posting synthetic alerts to the Alertmanager v2 API.
+type AlertmanagerV2PostAlert struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	EndsAt      string            `json:"endsAt,omitempty"`
+}
+
+// PostAlerts sends synthetic alerts to every alertmanager pod via exec.
+// Alerts posted to the Alertmanager API are not gossiped between peers,
+// so we must post to each pod individually to ensure the alert is visible
+// regardless of which pod handles subsequent GET requests.
+func (c *AlertmanagerClient) PostAlerts(ctx context.Context, alerts []AlertmanagerV2PostAlert) error {
+	body, err := json.Marshal(alerts)
+	if err != nil {
+		return fmt.Errorf("failed to marshal alerts: %w", err)
+	}
+
+	pods, err := c.kubeClient.CoreV1().Pods("openshift-monitoring").List(ctx, metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=alertmanager",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list alertmanager pods: %w", err)
+	}
+
+	for _, pod := range pods.Items {
+		if err := c.execCurlPost(ctx, pod.Name, body); err != nil {
+			return fmt.Errorf("failed to post alerts to %s: %w", pod.Name, err)
+		}
+	}
+	return nil
+}
+
+func (c *AlertmanagerClient) execCurlPost(ctx context.Context, podName string, jsonBody []byte) error {
+	req := c.kubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace("openshift-monitoring").
+		SubResource("exec").
+		VersionedParams(&v1.PodExecOptions{
+			Container: "alertmanager",
+			Command: []string{
+				"curl", "-sf",
+				"-X", "POST",
+				"-H", "Content-Type: application/json",
+				"-d", string(jsonBody),
+				"http://localhost:9093/api/v2/alerts",
+			},
+			Stdout: true,
+			Stderr: true,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(c.restConfig, "POST", req.URL())
+	if err != nil {
+		return fmt.Errorf("failed to create executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}); err != nil {
+		return fmt.Errorf("exec failed (stderr: %s): %w", stderr.String(), err)
+	}
+	return nil
+}
+
+// ResolveAlerts resolves previously posted synthetic alerts by setting endsAt to the past.
+func (c *AlertmanagerClient) ResolveAlerts(ctx context.Context, alerts []AlertmanagerV2PostAlert) error {
+	resolved := make([]AlertmanagerV2PostAlert, len(alerts))
+	past := time.Now().Add(-1 * time.Minute).UTC().Format(time.RFC3339)
+	for i, a := range alerts {
+		resolved[i] = AlertmanagerV2PostAlert{
+			Labels:      a.Labels,
+			Annotations: a.Annotations,
+			EndsAt:      past,
+		}
+	}
+	return c.PostAlerts(ctx, resolved)
 }


### PR DESCRIPTION
## Summary

Ports the `AlertmanagerInhibitions` e2e tests from osde2e into this repo, adapted to the CAMO test framework.

### What's tested

- **Inhibit rules exist**: Validates that the alertmanager config contains inhibit rules with a `severity=critical` source match (existing `Describe("Alertmanager configuration structure")` block).
- **Inhibition actually works**: Injects synthetic `ClusterOperatorDegraded` and `ClusterOperatorDown` alerts directly into the Alertmanager v2 API, then verifies `ClusterOperatorDown` is present with `state=suppressed`. This proves the inhibition rule is working end-to-end.

### Approach: synthetic alert injection

Instead of degrading a real cluster operator (risky, slow, doesn't verify actual suppression), we POST synthetic alerts to Alertmanager's `/api/v2/alerts` endpoint. Alertmanager treats them identically to real alerts — inhibition rules apply immediately.

POST uses pod exec to reach each alertmanager instance directly, since alerts posted via the API are not gossiped between peers and the external route load-balances across replicas. Cleanup resolves the synthetic alerts by posting them with `endsAt` in the past.

Test completes in ~1 seconds with no cluster state changes.

### New utilities in `test/e2e/utils/`

- `AlertmanagerClient` — authenticated HTTP client for the Alertmanager v2 API (GET via external route, POST via pod exec)
- `PostAlerts()` / `ResolveAlerts()` — inject and clean up synthetic alerts
- `GetAlerts()` / `GetAlertsByName()` — query alert state including inhibition status

## Test plan

- [x] `go build -tags osde2e ./test/e2e/...` compiles cleanly
- [x] All inhibition specs pass against a live cluster (~11s)
- [x] Existing tests unaffected

## Related

Corresponding osde2e test removal: https://github.com/openshift/osde2e/pull/3222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that injects synthetic alerts and verifies suppression behavior until a target alert is marked suppressed and lists its inhibitor.
  * Added test utilities to query Alertmanager v2, post and resolve synthetic alerts, and handle authentication and TLS for connecting to the Alertmanager endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->