### PR TITLE
Remove ttlSecondsAfterFinished from OLM cleanup Job

### DIFF
--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -71,7 +71,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -71,7 +71,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:

--- a/deploy_pko/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/Cleanup-OLM-Job.yaml
@@ -71,7 +71,6 @@ metadata:
     package-operator.run/phase: cleanup-deploy
     package-operator.run/collision-protection: IfNoController
 spec:
-  ttlSecondsAfterFinished: 100
   template:
     metadata:
       annotations:


### PR DESCRIPTION
## Problem

`ttlSecondsAfterFinished: 100` causes the completed cleanup Job to be deleted after 100s. The current ClusterObjectSet immediately recreates it. When a new PKO revision arrives, it tries to adopt the freshly created (not yet Complete) Job — Kubernetes rejects this because `spec.template` is immutable after creation (Kubernetes auto-injects `controller-uid`/`job-name` labels into the pod template on creation, creating a spec diff that can never be reconciled).

This blocks **all** PKO revision rollouts after initial deployment.

## Root cause

PKO skips spec apply on **Complete** Jobs and only transfers the owner reference (metadata-only patch). But when TTL deletes the Job and PKO recreates it, the new Job is not yet Complete — so the next revision attempts a full spec apply, which fails due to immutability.

## Fix

Remove `ttlSecondsAfterFinished`. The Job stays permanently Complete between revisions, allowing PKO to transfer ownership without spec modification.

Mirrors openshift/osd-metrics-exporter#322 which hit the same issue.

## Test plan
- [ ] CI pipeline passes
- [ ] Verify ClusterPackage reaches Available after a revision rollout on integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * Cleanup jobs will no longer automatically expire after a fixed time period; job retention will now follow cluster defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->