### PR TITLE
Use version-based cleanup Job naming with activeDeadlineSeconds

### DIFF
--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -65,12 +65,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-testabc123
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  activeDeadlineSeconds: 300
   template:
     metadata:
       annotations:

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -65,12 +65,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-testabc123
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  activeDeadlineSeconds: 300
   template:
     metadata:
       annotations:

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -65,12 +65,12 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: olm-cleanup
+  name: olm-cleanup-{{ .config.version }}
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: cleanup-deploy
-    package-operator.run/collision-protection: IfNoController
 spec:
+  activeDeadlineSeconds: 300
   template:
     metadata:
       annotations:

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -37,6 +37,12 @@ spec:
           description: FedRAMP mode flag
           type: string
           default: "false"
+        version:
+          description: Operator version tag for resource naming
+          type: string
+          default: "0000000"
+          pattern: "^[a-z0-9][a-z0-9.-]*$"
+          maxLength: 51
       type: object
 test:
   template:
@@ -49,6 +55,7 @@ test:
       config:
         image: "quay.io/example/configure-alertmanager-operator:test"
         fedramp: "false"
+        version: "testabc123"
   - name: fedramp
     context:
       package:
@@ -58,3 +65,4 @@ test:
       config:
         image: "quay.io/example/configure-alertmanager-operator:test"
         fedramp: "true"
+        version: "testabc123"

--- a/hack/pko/clusterpackage-direct.yaml
+++ b/hack/pko/clusterpackage-direct.yaml
@@ -33,3 +33,4 @@ objects:
       config:
         image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
         fedramp: ${FEDRAMP}
+        version: ${IMAGE_TAG}

--- a/hack/pko/clusterpackage.yaml
+++ b/hack/pko/clusterpackage.yaml
@@ -47,3 +47,4 @@ objects:
             config:
               image: ${OPERATOR_IMAGE}:${IMAGE_TAG}
               fedramp: ${FEDRAMP}
+              version: ${IMAGE_TAG}


### PR DESCRIPTION
## Problem

Kubernetes Jobs are immutable after creation — `spec.template` cannot be modified. Kubernetes also auto-injects labels (`controller-uid`, `job-name`) into the pod template at creation time. When PKO transitions between package revisions, it attempts to adopt existing Jobs from the previous ObjectSet. The spec diff between what the new revision expects and what exists on the cluster causes:

```
Job.batch "olm-cleanup" is invalid: spec.template: field is immutable
```

This can occur in several scenarios:
- **Static Job naming**: Every revision uses the same Job name, guaranteeing adoption conflicts on any upgrade
- **TTL-based cleanup**: `ttlSecondsAfterFinished` deletes the completed Job, but the current ObjectSet immediately recreates it — the recreated Job has new auto-injected labels that the next revision cannot reconcile
- **Hung or failed Jobs**: A Job that never reaches a terminal state blocks adoption by the next revision and can leave orphaned pods consuming resources indefinitely

## Fix

- **Version-suffixed Job names**: `olm-cleanup-{{ .config.version }}` — each revision gets a unique Job name, eliminating adoption conflicts entirely
- **`activeDeadlineSeconds: 300`**: Ensures hung cleanup Jobs are terminated after 5 minutes, preventing orphaned pods and guaranteeing Jobs reach a terminal state
- Add `version` config parameter to `manifest.yaml` (default `"0000000"`, with `pattern` and `maxLength` validation for safe Kubernetes resource names)
- Pass `IMAGE_TAG` as `version` through clusterpackage templates (`IMAGE_TAG` is already an existing SAAS parameter — no app-interface changes needed)
- Rename `Cleanup-OLM-Job.yaml` to `.gotmpl` for template rendering
- Remove `collision-protection` from Job (unique names prevent collision)

Job name renders to e.g. `olm-cleanup-7158003`, matching the operator version for easy identification. Old Jobs are cleaned up automatically when their owning ClusterObjectSet is archived during revision transitions.

## Self-remediation

This fix self-remediates clusters stuck on previous approaches (static naming, TTL). The new revision creates `olm-cleanup-<version>` instead of trying to adopt the old `olm-cleanup`. No manual `oc delete job` needed.

## Transition safety

| Scenario | Result |
|---|---|
| New image + new SAAS (normal) | `olm-cleanup-7158003` ✓ |
| New image + old SAAS (no version passed) | `olm-cleanup-0000000` (default) ✓ |
| Old image + new SAAS (version passed) | PKO prunes unknown config field, old Job unchanged ✓ |
| Old image + old SAAS (no change) | Old `olm-cleanup` unchanged ✓ |

No ordering dependency between this PR and the app-interface SAAS.

## Test results

Tested 16 scenarios on a dedicated integration cluster (`matttesti505`) covering PKO upgrades, rollbacks, default values, hung Jobs, deadline behavior, and transition from static naming:

| Test | Description | Result |
|------|-------------|--------|
| 1 | **Static → versioned transition**: Pre-PR image (`olm-cleanup`) upgraded to PR image (`olm-cleanup-version-a`). Proves existing clusters can adopt the PR without manual intervention. | **PASS** |
| 2 | **PKO-to-PKO upgrade**: `version-a` → `version-b`. Different Job names, no immutability error. Core use case that was broken with static naming. | **PASS** |
| 3 | **Second consecutive upgrade**: `version-b` → `version-c`. Pattern holds across multiple revisions. | **PASS** |
| 4 | **Rollback**: `version-c` → `version-a`. Previously-used version redeploys without collision. | **PASS** |
| 5 | **Default value (no version param)**: Job renders as `olm-cleanup-0000000`. Backwards compatible. | **PASS** |
| 6 | **Repeated default value**: Second deploy without version. PKO deduplicated identical content — no collision. | **PASS** |
| 7 | **Pre-existing hung Job, same name**: Confirms immutability error only occurs when Job names collide (cannot happen in normal operations). | **Expected fail** |
| 8 | **Hung Job, different version**: Hung `olm-cleanup-hung-test`, upgrade to `olm-cleanup-version-b`. Upgrade succeeded. Orphaned pod without deadline motivated adding `activeDeadlineSeconds`. | **PASS** |
| 9 | **Hung Job from previous version, upgrade to different version**: Deployed PKO image with hung cleanup script, then upgraded to normal image with different version suffix. Proves hung Jobs don't block upgrades when names differ. | **PASS** |
| 10 | **activeDeadlineSeconds — normal completion**: 60s deadline, script completes in ~4s, then upgrade. Deadline doesn't interfere with normal execution. | **PASS** |
| 11 | **activeDeadlineSeconds — timeout then upgrade**: Hung script killed by 60s deadline, marked Failed. Upgrade succeeded, no orphaned pods. | **PASS** |
| 12 | **Upgrade during slow Job**: 30s sleep + 60s deadline. Upgrade at 10s while Job running. Both completed independently, no interference. | **PASS** |
| 13 | **Upgrade while pod Terminating**: Deadline killed pod, upgrade triggered during Terminating state. Different names, no conflict. | **PASS** |
| 14 | **Upgrade during retry cycle**: Deadline killed first pod, retry pending. Upgrade succeeded, retrying Job cleaned up with archived ObjectSet. | **PASS** |
| 15 | **Production 300s deadline — deploy and upgrade**: Deploy + upgrade with `activeDeadlineSeconds: 300`. Normal operations verified end-to-end. | **PASS** |
| 16 | **Operator health validation**: Across all tests — pod running with zero restarts, alertmanager config valid, no errors in CAMO or alertmanager logs. | **PASS** |

## Test plan
- [x] `kubectl-package validate` passes
- [x] Fixtures render correctly with version suffix
- [x] CI pipeline passes
- [x] 16 scenario test matrix executed on integration cluster — all pass
- [x] Verified self-remediation: static `olm-cleanup` → versioned `olm-cleanup-<version>`
- [x] Verified `activeDeadlineSeconds` prevents orphaned pods from hung Jobs
- [x] Verified operator health (pod running, no errors, alertmanager config valid) across all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)