### PR TITLE
Add collision-protection to all PKO deploy resources for OLM migration

### DIFF
--- a/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-edit.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-edit
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-view.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-view
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-edit
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-prom
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-view
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/default/Role-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/Role-configure-alertmanager-operator.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/.test-fixtures/default/RoleBinding-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/RoleBinding-configure-alertmanager-operator.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator

--- a/deploy_pko/.test-fixtures/default/ServiceAccount-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/default/ServiceAccount-configure-alertmanager-operator.yaml
@@ -3,5 +3,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
   name: configure-alertmanager-operator
   namespace: openshift-monitoring

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-edit.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-edit
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-view.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-view
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-edit
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-prom
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRoleBinding-configure-alertmanager-operator-view.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-view
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/.test-fixtures/fedramp/Role-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Role-configure-alertmanager-operator.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/.test-fixtures/fedramp/RoleBinding-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/RoleBinding-configure-alertmanager-operator.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator

--- a/deploy_pko/.test-fixtures/fedramp/ServiceAccount-configure-alertmanager-operator.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ServiceAccount-configure-alertmanager-operator.yaml
@@ -3,5 +3,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
   name: configure-alertmanager-operator
   namespace: openshift-monitoring

--- a/deploy_pko/ClusterRole-configure-alertmanager-operator-edit.yaml.gotmpl
+++ b/deploy_pko/ClusterRole-configure-alertmanager-operator-edit.yaml.gotmpl
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-edit
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/ClusterRole-configure-alertmanager-operator-view.yaml.gotmpl
+++ b/deploy_pko/ClusterRole-configure-alertmanager-operator-view.yaml.gotmpl
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-view
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml.gotmpl
+++ b/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-edit.yaml.gotmpl
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-edit
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
+++ b/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-prom.yaml
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-prom
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-view.yaml.gotmpl
+++ b/deploy_pko/ClusterRoleBinding-configure-alertmanager-operator-view.yaml.gotmpl
@@ -4,6 +4,7 @@ metadata:
   name: configure-alertmanager-operator-view
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/deploy_pko/Role-configure-alertmanager-operator.yaml.gotmpl
+++ b/deploy_pko/Role-configure-alertmanager-operator.yaml.gotmpl
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 rules:
 - apiGroups:
   - ''

--- a/deploy_pko/RoleBinding-configure-alertmanager-operator.yaml.gotmpl
+++ b/deploy_pko/RoleBinding-configure-alertmanager-operator.yaml.gotmpl
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
 subjects:
 - kind: ServiceAccount
   name: configure-alertmanager-operator

--- a/deploy_pko/ServiceAccount-configure-alertmanager-operator.yaml.gotmpl
+++ b/deploy_pko/ServiceAccount-configure-alertmanager-operator.yaml.gotmpl
@@ -3,5 +3,6 @@ kind: ServiceAccount
 metadata:
   annotations:
     package-operator.run/phase: rbac
+    package-operator.run/collision-protection: IfNoController
   name: configure-alertmanager-operator
   namespace: openshift-monitoring

--- a/deploy_pko/manifest.yaml
+++ b/deploy_pko/manifest.yaml
@@ -45,6 +45,8 @@ spec:
           maxLength: 51
       type: object
 test:
+  kubeconform:
+    kubernetesVersion: v1.28.2
   template:
   - name: default
     context:


### PR DESCRIPTION
## Summary

This PR adds `collision-protection: IfNoController` to all RBAC and ServiceAccount templates in `deploy_pko/` and their corresponding test fixtures. Without this annotation, PKO defaults to `Prevent` mode which refuses to adopt pre-existing resources during OLM-to-PKO migration. With `IfNoController`, PKO can adopt resources that exist on the cluster but have no PKO controller owner, allowing migrations to proceed without manual cleanup. Previously only the Deployment and Cleanup Job had this annotation — the remaining 8 resources (2 ClusterRoles, 3 ClusterRoleBindings, 1 Role, 1 RoleBinding, 1 ServiceAccount) were previously deleted during the cleanup phase but are now covered by collision-protection instead. The 16 fixture files (8 per test context) reflect these template changes.

This PR also adds `kubeconform` validation (`kubernetesVersion: v1.28.2`) to `manifest.yaml`, enabling `make validate-pko-fixtures` and `make container-validate` to check rendered templates against the Kubernetes API schema before deployment.

## Test plan
- [x] `validate-pko-fixtures` passes in container
- [x] Verified from cloned PR branch: 20/20 fixtures and 10/10 templates have collision-protection
- [ ] CI pipeline passes
- [ ] Verify ClusterPackage reaches Available on clusters migrating from OLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)