### PR TITLE
ROSAENG-1157 | Drop ClusterLogForwarderOutputErrorRate alerts

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778461551
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778461551
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -422,6 +422,7 @@ func createSubroutes(namespaceList []string, receiver receiverType) *alertmanage
 		// For detail explanation, please check https://issues.redhat.com/browse/OSD-17371
 		// vector alerts
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterLogForwarderRuntimeConfigurationMissingUnmatched", "namespace": "openshift-logging"}},
+		{Receiver: receiverNull, Match: map[string]string{"alertname": "ClusterLogForwarderOutputErrorRate", "namespace": "openshift-logging"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CollectorNodeDown", "namespace": "openshift-logging"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CollectorHighErrorRate", "namespace": "openshift-logging"}},
 		{Receiver: receiverNull, Match: map[string]string{"alertname": "CollectorVeryHighErrorRate", "namespace": "openshift-logging"}},


### PR DESCRIPTION
This alert was added here: https://github.com/openshift/cluster-logging-operator/pull/3137. This alert is not something SREP should be tasked with triaging, so silencing it here.

https://redhat.pagerduty.com/incidents/Q2LTARFJT6Z7XU - Triggered twice for two clusters owned by the same customer, and was related directly to their config. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated alert silencing configuration to properly handle cluster log forwarder output rate alerts in the logging namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->