### PR TITLE
Improve cleanup Job resilience for transient and image pull failures

### DIFF
--- a/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/default/Cleanup-OLM-Job.yaml
@@ -70,7 +70,7 @@ metadata:
   annotations:
     package-operator.run/phase: cleanup-deploy
 spec:
-  activeDeadlineSeconds: 300
+  backoffLimit: 40
   template:
     metadata:
       annotations:
@@ -78,7 +78,7 @@ spec:
     spec:
       serviceAccountName: olm-cleanup
       priorityClassName: openshift-user-critical
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: delete-csv
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -93,18 +93,18 @@ spec:
               ERRORS=""
               NS="openshift-monitoring"
 
-              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
+              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete Subscription. "
 
-              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CSV. "
 
-              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
+              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
               if [ -n "$ERRORS" ]; then
-                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2
-                oc create -f - <<EVENTEOF || echo "Failed to create warning event. See script output" >&2
+                echo "ERROR: OLM cleanup failed, will retry: ${ERRORS}" >&2
+                oc create -f - <<EVENTEOF || echo "Failed to create warning event" >&2
               apiVersion: v1
               kind: Event
               metadata:
@@ -115,9 +115,10 @@ spec:
                 kind: Namespace
                 name: ${NS}
               reason: OLMCleanupErrors
-              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              message: "OLM cleanup job failed, will retry: ${ERRORS}"
               type: Warning
               EVENTEOF
+                exit 1
               fi
           resources:
             requests:

--- a/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/Cleanup-OLM-Job.yaml
@@ -70,7 +70,7 @@ metadata:
   annotations:
     package-operator.run/phase: cleanup-deploy
 spec:
-  activeDeadlineSeconds: 300
+  backoffLimit: 40
   template:
     metadata:
       annotations:
@@ -78,7 +78,7 @@ spec:
     spec:
       serviceAccountName: olm-cleanup
       priorityClassName: openshift-user-critical
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: delete-csv
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -93,18 +93,18 @@ spec:
               ERRORS=""
               NS="openshift-monitoring"
 
-              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
+              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete Subscription. "
 
-              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CSV. "
 
-              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
+              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
               if [ -n "$ERRORS" ]; then
-                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2
-                oc create -f - <<EVENTEOF || echo "Failed to create warning event. See script output" >&2
+                echo "ERROR: OLM cleanup failed, will retry: ${ERRORS}" >&2
+                oc create -f - <<EVENTEOF || echo "Failed to create warning event" >&2
               apiVersion: v1
               kind: Event
               metadata:
@@ -115,9 +115,10 @@ spec:
                 kind: Namespace
                 name: ${NS}
               reason: OLMCleanupErrors
-              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              message: "OLM cleanup job failed, will retry: ${ERRORS}"
               type: Warning
               EVENTEOF
+                exit 1
               fi
           resources:
             requests:

--- a/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
+++ b/deploy_pko/Cleanup-OLM-Job.yaml.gotmpl
@@ -70,7 +70,7 @@ metadata:
   annotations:
     package-operator.run/phase: cleanup-deploy
 spec:
-  activeDeadlineSeconds: 300
+  backoffLimit: 40
   template:
     metadata:
       annotations:
@@ -78,7 +78,7 @@ spec:
     spec:
       serviceAccountName: olm-cleanup
       priorityClassName: openshift-user-critical
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: delete-csv
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -93,18 +93,18 @@ spec:
               ERRORS=""
               NS="openshift-monitoring"
 
-              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --ignore-not-found=true \
+              oc -n "$NS" delete subscription.operators.coreos.com configure-alertmanager-operator --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete Subscription. "
 
-              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --ignore-not-found=true \
+              oc -n "$NS" delete csv -l "operators.coreos.com/configure-alertmanager-operator.${NS}" --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CSV. "
 
-              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --ignore-not-found=true \
+              oc -n "$NS" delete catalogsource.operators.coreos.com configure-alertmanager-operator-registry --timeout=300s --ignore-not-found=true \
                 || ERRORS="${ERRORS}Failed to delete CatalogSource. "
 
               if [ -n "$ERRORS" ]; then
-                echo "WARNING: OLM cleanup completed with errors: ${ERRORS}" >&2
-                oc create -f - <<EVENTEOF || echo "Failed to create warning event. See script output" >&2
+                echo "ERROR: OLM cleanup failed, will retry: ${ERRORS}" >&2
+                oc create -f - <<EVENTEOF || echo "Failed to create warning event" >&2
               apiVersion: v1
               kind: Event
               metadata:
@@ -115,9 +115,10 @@ spec:
                 kind: Namespace
                 name: ${NS}
               reason: OLMCleanupErrors
-              message: "OLM cleanup job completed with errors: ${ERRORS}"
+              message: "OLM cleanup job failed, will retry: ${ERRORS}"
               type: Warning
               EVENTEOF
+                exit 1
               fi
           resources:
             requests:


### PR DESCRIPTION
#### What

- Remove `activeDeadlineSeconds` which permanently killed the Job on first failure with no retries
- Switch `restartPolicy` from `Never` to `OnFailure` so the container retries in-place
- Set `backoffLimit: 40` (~3 hours of retries with exponential backoff)
- Add `--timeout=300s` to each `oc delete` command to bound stuck finalizers
- Exit non-zero on errors so `OnFailure` triggers a retry

#### Why

On a staging cluster, the OLM cleanup Job failed because the internal image-registry was degraded (OIDC credential issue). The pod couldn't pull the CLI image and sat in `ImagePullBackOff` for 5 minutes until `activeDeadlineSeconds: 300` permanently killed the Job. No retries, no recovery. The CSV, Subscription, and CatalogSource remained orphaned.

With `restartPolicy: OnFailure`, image pull failures stay in `ImagePullBackOff` indefinitely (kubelet retries without consuming `backoffLimit`). When the registry recovers, the pull succeeds and the cleanup runs. Script-level failures (API errors, stuck finalizers) consume `backoffLimit` with exponential backoff, retrying for ~3 hours before giving up.

The cleanup Job is non-blocking — PKO deploys the operator regardless of Job status. Failed cleanups only leave inert OLM artifacts that don't affect operator functionality. On the next operator upgrade, the version-suffixed Job name (`olm-cleanup-<version>`) creates a fresh Job, replacing the failed one.

#### Tickets

[SREP-3848](https://redhat.atlassian.net/browse/SREP-3848)

#### Validation

Tested on a live ROSA cluster with hive paused:

- [x] Happy path: no OLM artifacts, Job completes in 3-5s
- [x] OLM artifacts present: Subscription, CSV, CatalogSource deleted successfully
- [x] Script failure: `exit 1` triggers container restart via `OnFailure`
- [x] Backoff limit: container restarts with exponential backoff, exhausts limit correctly
- [x] `--timeout=300s` present on all `oc delete` commands
- [x] `make container-generate-pko-fixtures` passes

#### Dependency

None.

[SREP-3848]: https://redhat.atlassian.net/browse/SREP-3848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OLM cleanup job reliability by enabling automatic retries on failure with a maximum of 40 attempts.
  * Added explicit timeout parameters to deletion operations to prevent indefinite hangs.
  * Enhanced error messaging to clearly indicate when cleanup will retry after encountering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->