### PR TITLE
[SREP-2307] Add cluster region to PagerDuty configuration details

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -260,6 +260,11 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		reqLogger.Error(err, "Error reading cluster id.")
 	}
 
+	clusterRegion, err := r.getClusterRegion(ctx)
+	if err != nil {
+		reqLogger.Error(err, "Error reading cluster region.")
+	}
+
 	alertmanagerconfig := createAlertManagerConfig(reqLogger,
 		pagerdutyRoutingKey,
 		cadPagerdutyRoutingKey,
@@ -269,6 +274,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		watchdogURL,
 		ocmAgentURL,
 		clusterID,
+		clusterRegion,
 		clusterProxy,
 		osdNamespaces)
 
@@ -563,7 +569,7 @@ func createOCMAgentReceiver(ocmAgentURL string) []*alertmanager.Receiver {
 }
 
 // createPagerdutyConfig creates an AlertManager PagerdutyConfig for PagerDuty in memory.
-func createPagerdutyConfig(pagerdutyRoutingKey, clusterID string, clusterProxy string) *alertmanager.PagerdutyConfig {
+func createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion string, clusterProxy string) *alertmanager.PagerdutyConfig {
 	detailsMap := map[string]string{
 		"alert_name":   `{{ .CommonLabels.alertname }}`,
 		"link":         `{{ if .CommonAnnotations.runbook_url }}{{ .CommonAnnotations.runbook_url }}{{ else if .CommonAnnotations.link }}{{ .CommonAnnotations.link }}{{ else if .CommonLabels.link }}{{ .CommonLabels.link }}{{ else }}https://github.com/openshift/ops-sop/tree/master/v4/alerts/{{ .CommonLabels.alertname }}.md{{ end }}`,
@@ -572,6 +578,7 @@ func createPagerdutyConfig(pagerdutyRoutingKey, clusterID string, clusterProxy s
 		"num_resolved": `{{ .Alerts.Resolved | len }}`,
 		"resolved":     `{{ template "pagerduty.default.instances" .Alerts.Resolved }}`,
 		"cluster_id":   clusterID,
+		"region":       clusterRegion,
 	}
 	clientURL := `{{ template "pagerduty.default.clientURL" . }}`
 
@@ -579,6 +586,7 @@ func createPagerdutyConfig(pagerdutyRoutingKey, clusterID string, clusterProxy s
 		detailsMap["ocm_link"] = ``
 		detailsMap["resolved"] = ``
 		detailsMap["cluster_id"] = ``
+		detailsMap["region"] = ``
 		detailsMap["firing"] = ``
 
 		// The default value contains the cluster name which is considered sensitive
@@ -597,7 +605,7 @@ func createPagerdutyConfig(pagerdutyRoutingKey, clusterID string, clusterProxy s
 	}
 }
 
-func createCADPagerdutyReceivers(pagerdutyRoutingKey, clusterID string, clusterProxy string) []*alertmanager.Receiver {
+func createCADPagerdutyReceivers(pagerdutyRoutingKey, clusterID, clusterRegion string, clusterProxy string) []*alertmanager.Receiver {
 	if pagerdutyRoutingKey == "" {
 		return []*alertmanager.Receiver{}
 	}
@@ -605,13 +613,13 @@ func createCADPagerdutyReceivers(pagerdutyRoutingKey, clusterID string, clusterP
 	return []*alertmanager.Receiver{
 		{
 			Name:             receiverCADPagerduty,
-			PagerdutyConfigs: []*alertmanager.PagerdutyConfig{createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterProxy)},
+			PagerdutyConfigs: []*alertmanager.PagerdutyConfig{createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion, clusterProxy)},
 		},
 	}
 }
 
 // createPagerdutyReceivers creates an AlertManager Receiver for PagerDuty in memory.
-func createPagerdutyReceivers(pagerdutyRoutingKey, clusterID string, clusterProxy string) []*alertmanager.Receiver {
+func createPagerdutyReceivers(pagerdutyRoutingKey, clusterID, clusterRegion string, clusterProxy string) []*alertmanager.Receiver {
 	if pagerdutyRoutingKey == "" {
 		return []*alertmanager.Receiver{}
 	}
@@ -619,12 +627,12 @@ func createPagerdutyReceivers(pagerdutyRoutingKey, clusterID string, clusterProx
 	receivers := []*alertmanager.Receiver{
 		{
 			Name:             receiverPagerduty,
-			PagerdutyConfigs: []*alertmanager.PagerdutyConfig{createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterProxy)},
+			PagerdutyConfigs: []*alertmanager.PagerdutyConfig{createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion, clusterProxy)},
 		},
 	}
 
 	// make-it-warning overrides the severity
-	pdconfig := createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterProxy)
+	pdconfig := createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion, clusterProxy)
 	pdconfig.Severity = "warning"
 	receivers = append(receivers, &alertmanager.Receiver{
 		Name:             receiverMakeItWarning,
@@ -632,7 +640,7 @@ func createPagerdutyReceivers(pagerdutyRoutingKey, clusterID string, clusterProx
 	})
 
 	// make-it-error overrides the severity
-	highpdconfig := createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterProxy)
+	highpdconfig := createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion, clusterProxy)
 	highpdconfig.Severity = "error"
 	receivers = append(receivers, &alertmanager.Receiver{
 		Name:             receiverMakeItError,
@@ -640,7 +648,7 @@ func createPagerdutyReceivers(pagerdutyRoutingKey, clusterID string, clusterProx
 	})
 
 	// make-it-critical overrides the severity
-	criticalpdconfig := createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterProxy)
+	criticalpdconfig := createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion, clusterProxy)
 	criticalpdconfig.Severity = "critical"
 	receivers = append(receivers, &alertmanager.Receiver{
 		Name:             receiverMakeItCritical,
@@ -752,7 +760,7 @@ func createHttpConfig(clusterProxy string) alertmanager.HttpConfig {
 }
 
 // createAlertManagerConfig creates an AlertManager Config in memory based on the provided input parameters.
-func createAlertManagerConfig(reqLogger logr.Logger, pagerdutyRoutingKey, cadPagerdutyRoutingKey, goalertURLlow, goalertURLhigh, goalertURLheartbeat, watchdogURL, ocmAgentURL, clusterID string, clusterProxy string, namespaceList []string) *alertmanager.Config {
+func createAlertManagerConfig(reqLogger logr.Logger, pagerdutyRoutingKey, cadPagerdutyRoutingKey, goalertURLlow, goalertURLhigh, goalertURLheartbeat, watchdogURL, ocmAgentURL, clusterID, clusterRegion string, clusterProxy string, namespaceList []string) *alertmanager.Config {
 	routes := []*alertmanager.Route{}
 	receivers := []*alertmanager.Receiver{}
 
@@ -770,13 +778,13 @@ func createAlertManagerConfig(reqLogger logr.Logger, pagerdutyRoutingKey, cadPag
 	if cadPagerdutyRoutingKey != "" {
 		reqLogger.Info("INFO: Configuring a CAD PagerDuty route and receiver")
 		routes = append(routes, createCADPagerdutyRoute())
-		receivers = append(receivers, createCADPagerdutyReceivers(cadPagerdutyRoutingKey, clusterID, clusterProxy)...)
+		receivers = append(receivers, createCADPagerdutyReceivers(cadPagerdutyRoutingKey, clusterID, clusterRegion, clusterProxy)...)
 	}
 
 	if pagerdutyRoutingKey != "" {
 		reqLogger.Info("INFO: Configuring a PagerDuty route and receiver")
 		routes = append(routes, createSubroutes(namespaceList, Pagerduty))
-		receivers = append(receivers, createPagerdutyReceivers(pagerdutyRoutingKey, clusterID, clusterProxy)...)
+		receivers = append(receivers, createPagerdutyReceivers(pagerdutyRoutingKey, clusterID, clusterRegion, clusterProxy)...)
 	}
 
 	if goalertURLlow != "" && goalertURLhigh != "" {
@@ -1127,6 +1135,48 @@ func (r *SecretReconciler) getClusterProxy() (string, error) {
 	// Only care about HTTPS proxy, as PD and DMS comms will be HTTPS
 	if proxy.Status.HTTPSProxy != "" {
 		return proxy.Status.HTTPSProxy, nil
+	}
+	return "", nil
+}
+
+// getClusterRegion returns the cloud provider region for the cluster by reading
+// the Infrastructure object's PlatformStatus. Supports AWS and GCP; returns an
+// empty string for other platforms or when the region is unavailable.
+func (r *SecretReconciler) getClusterRegion(ctx context.Context) (string, error) {
+	var infra configv1.Infrastructure
+	err := r.Client.Get(ctx, client.ObjectKey{Name: "cluster"}, &infra)
+	if err != nil {
+		return "", err
+	}
+
+	if infra.Status.PlatformStatus == nil {
+		return "", nil
+	}
+
+	switch infra.Status.PlatformStatus.Type {
+	case configv1.AWSPlatformType:
+		if infra.Status.PlatformStatus.AWS != nil {
+			return infra.Status.PlatformStatus.AWS.Region, nil
+		}
+	case configv1.GCPPlatformType:
+		if infra.Status.PlatformStatus.GCP != nil {
+			return infra.Status.PlatformStatus.GCP.Region, nil
+		}
+	case configv1.AzurePlatformType,
+		configv1.BareMetalPlatformType,
+		configv1.LibvirtPlatformType,
+		configv1.OpenStackPlatformType,
+		configv1.NonePlatformType,
+		configv1.VSpherePlatformType,
+		configv1.OvirtPlatformType,
+		configv1.IBMCloudPlatformType,
+		configv1.KubevirtPlatformType,
+		configv1.EquinixMetalPlatformType,
+		configv1.PowerVSPlatformType,
+		configv1.AlibabaCloudPlatformType,
+		configv1.NutanixPlatformType,
+		configv1.ExternalPlatformType:
+		return "", nil
 	}
 	return "", nil
 }

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -29,6 +29,7 @@ import (
 const (
 	exampleClusterId = "fake-cluster-id"
 	exampleProxy     = "https://fakeproxy.here"
+	exampleRegion    = "us-east-1"
 )
 
 var reqLogger = logf.Log.WithName("secret_controller")
@@ -959,7 +960,7 @@ func Test_createGoalertSubroute(t *testing.T) {
 }
 
 func Test_createPagerdutyReceivers_WithoutKey(t *testing.T) {
-	assertEquals(t, 0, len(createPagerdutyReceivers("", "", "")), "Number of Receivers")
+	assertEquals(t, 0, len(createPagerdutyReceivers("", "", "", "")), "Number of Receivers")
 }
 
 func Test_createGoalertReceivers_WithoutURL(t *testing.T) {
@@ -969,7 +970,7 @@ func Test_createGoalertReceivers_WithoutURL(t *testing.T) {
 func Test_createPagerdutyReceivers_WithKey(t *testing.T) {
 	key := "abcdefg1234567890"
 
-	receivers := createPagerdutyReceivers(key, exampleClusterId, exampleProxy)
+	receivers := createPagerdutyReceivers(key, exampleClusterId, exampleRegion, exampleProxy)
 
 	verifyPagerdutyReceivers(t, key, exampleProxy, receivers)
 }
@@ -1028,7 +1029,7 @@ func Test_createAlertManagerConfig_WithoutKey_WithoutURL(t *testing.T) {
 	gaLowURL := ""
 	gaHeartURL := ""
 
-	config := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -1053,7 +1054,7 @@ func Test_createAlertManagerConfig_WithKey_WithoutURL(t *testing.T) {
 	gaLowURL := ""
 	gaHeartURL := ""
 
-	config := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -1077,7 +1078,7 @@ func Test_createAlertManagerConfig_WithCADPagerDuty(t *testing.T) {
 	pdKey := "general-routing-key"
 	cadKey := "cad-routing-key"
 
-	config := createAlertManagerConfig(reqLogger, pdKey, cadKey, "", "", "", "", "", exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, cadKey, "", "", "", "", "", exampleClusterId, exampleRegion, exampleProxy, exampleManagedNamespaces)
 
 	assertEquals(t, 2, len(config.Route.Routes), "Route.Routes")
 	assertEquals(t, 6, len(config.Receivers), "Receivers")
@@ -1097,7 +1098,7 @@ func Test_createAlertManagerConfig_WithKey_WithWDURL_WithOAURL(t *testing.T) {
 	gaLowURL := "https://dummy-galow-url"
 	gaHeartURL := "https://dummy-gaheartbeat-url"
 
-	config := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, exampleManagedNamespaces)
+	config := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, exampleManagedNamespaces)
 
 	// verify static things
 	assertEquals(t, "5m", config.Global.ResolveTimeout, "Global.ResolveTimeout")
@@ -1147,6 +1148,7 @@ func Test_createAlertManagerConfig_WithoutKey_WithoutOA_WithWDURL(t *testing.T) 
 		wdURL,
 		oaURL,
 		exampleClusterId,
+		exampleRegion,
 		exampleProxy,
 		exampleManagedNamespaces)
 
@@ -1285,6 +1287,7 @@ func Test_createPagerdutySecret_Create(t *testing.T) {
 		wdURL,
 		oaURL,
 		exampleClusterId,
+		exampleRegion,
 		exampleProxy,
 		defaultNamespaces)
 
@@ -1303,6 +1306,7 @@ func Test_createPagerdutySecret_Create(t *testing.T) {
 	createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 	createClusterVersion(reconciler)
 	createClusterProxy(reconciler)
+	createClusterInfrastructure(reconciler)
 
 	// reconcile (one event should config everything)
 	req := createReconcileRequest(reconciler, "pd-secret")
@@ -1328,7 +1332,7 @@ func Test_createPagerdutySecret_Update(t *testing.T) {
 	var ret reconcile.Result
 	var err error
 
-	configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, defaultNamespaces)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1344,6 +1348,7 @@ func Test_createPagerdutySecret_Update(t *testing.T) {
 	createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 	createClusterVersion(reconciler)
 	createClusterProxy(reconciler)
+	createClusterInfrastructure(reconciler)
 
 	// reconcile (one event should config everything)
 	req := createReconcileRequest(reconciler, secretNamePD)
@@ -1377,7 +1382,7 @@ func Test_createGoalertSecret_Create(t *testing.T) {
 	gaLowURL := "https://dummy-galow-url"
 	gaHeartURL := "https://dummy-gaheartbeat-url"
 
-	configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, defaultNamespaces)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1400,6 +1405,7 @@ func Test_createGoalertSecret_Create(t *testing.T) {
 	createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 	createClusterVersion(reconciler)
 	createClusterProxy(reconciler)
+	createClusterInfrastructure(reconciler)
 
 	// reconcile (one event should config everything)
 	req := createReconcileRequest(reconciler, "goalert-secret")
@@ -1425,7 +1431,7 @@ func Test_createGoalertSecret_Update(t *testing.T) {
 	var ret reconcile.Result
 	var err error
 
-	configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+	configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, defaultNamespaces)
 
 	verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1448,6 +1454,7 @@ func Test_createGoalertSecret_Update(t *testing.T) {
 	createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 	createClusterVersion(reconciler)
 	createClusterProxy(reconciler)
+	createClusterInfrastructure(reconciler)
 
 	// reconcile (one event should config everything)
 	req := createReconcileRequest(reconciler, secretNameGoalert)
@@ -1488,6 +1495,25 @@ func createClusterVersion(reconciler *SecretReconciler) {
 		},
 	}
 	if err := reconciler.Client.Create(context.TODO(), clusterVersion); err != nil {
+		panic(err)
+	}
+}
+
+func createClusterInfrastructure(reconciler *SecretReconciler) {
+	infra := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+				AWS: &configv1.AWSPlatformStatus{
+					Region: exampleRegion,
+				},
+			},
+		},
+	}
+	if err := reconciler.Client.Create(context.TODO(), infra); err != nil {
 		panic(err)
 	}
 }
@@ -1622,6 +1648,7 @@ func Test_SecretReconciler(t *testing.T) {
 		createNamespace(reconciler, t)
 		createClusterVersion(reconciler)
 		createClusterProxy(reconciler)
+		createClusterInfrastructure(reconciler)
 
 		pdKey := ""
 		wdURL := ""
@@ -1632,7 +1659,7 @@ func Test_SecretReconciler(t *testing.T) {
 
 		// Create the secrets for this specific test.
 		if tt.amExists {
-			if err := writeAlertManagerConfig(context.Background(), reconciler, reqLogger, createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, "", "", defaultNamespaces)); err != nil {
+			if err := writeAlertManagerConfig(context.Background(), reconciler, reqLogger, createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, "", "", "", defaultNamespaces)); err != nil {
 				t.Fatalf("Failed to write alertmanager config in test setup: %v", err)
 			}
 		}
@@ -1665,7 +1692,7 @@ func Test_SecretReconciler(t *testing.T) {
 			createConfigMap(reconciler, cmNameOcmAgent, cmKeyOCMAgent, oaURL)
 		}
 
-		configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+		configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, wdURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, defaultNamespaces)
 
 		verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -1739,8 +1766,9 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 		createNamespace(reconciler, t)
 		createClusterVersion(reconciler)
 		createClusterProxy(reconciler)
+		createClusterInfrastructure(reconciler)
 
-		if err := writeAlertManagerConfig(context.Background(), reconciler, reqLogger, createAlertManagerConfig(reqLogger, "", "", "", "", "", "", "", "", "", defaultNamespaces)); err != nil {
+		if err := writeAlertManagerConfig(context.Background(), reconciler, reqLogger, createAlertManagerConfig(reqLogger, "", "", "", "", "", "", "", "", "", "", defaultNamespaces)); err != nil {
 			t.Fatalf("Failed to write alertmanager config in test setup: %v", err)
 		}
 
@@ -1783,7 +1811,7 @@ func Test_SecretReconciler_Readiness(t *testing.T) {
 			oaURL = ""
 		}
 
-		configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, dmsURL, oaURL, exampleClusterId, exampleProxy, defaultNamespaces)
+		configExpected := createAlertManagerConfig(reqLogger, pdKey, "", gaLowURL, gaHighURL, gaHeartURL, dmsURL, oaURL, exampleClusterId, exampleRegion, exampleProxy, defaultNamespaces)
 
 		verifyInhibitRules(t, configExpected.InhibitRules)
 
@@ -2214,6 +2242,117 @@ func Test_getClusterProxy_Empty(t *testing.T) {
 	}
 }
 
+// Test_getClusterRegion_AWS validates region extraction from AWS PlatformStatus
+func Test_getClusterRegion_AWS(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadiness := readiness.NewMockInterface(ctrl)
+	reconciler := createReconciler(t, mockReadiness)
+	createNamespace(reconciler, t)
+
+	expectedRegion := "eu-west-1"
+
+	infra := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+				AWS: &configv1.AWSPlatformStatus{
+					Region: expectedRegion,
+				},
+			},
+		},
+	}
+
+	err := reconciler.Client.Create(context.TODO(), infra)
+	if err != nil {
+		t.Fatalf("Failed to create Infrastructure: %v", err)
+	}
+
+	region, err := reconciler.getClusterRegion(context.TODO())
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if region != expectedRegion {
+		t.Fatalf("Expected region %s, got: %s", expectedRegion, region)
+	}
+}
+
+// Test_getClusterRegion_GCP validates region extraction from GCP PlatformStatus
+func Test_getClusterRegion_GCP(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadiness := readiness.NewMockInterface(ctrl)
+	reconciler := createReconciler(t, mockReadiness)
+	createNamespace(reconciler, t)
+
+	expectedRegion := "us-central1"
+
+	infra := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: configv1.GCPPlatformType,
+				GCP: &configv1.GCPPlatformStatus{
+					Region: expectedRegion,
+				},
+			},
+		},
+	}
+
+	err := reconciler.Client.Create(context.TODO(), infra)
+	if err != nil {
+		t.Fatalf("Failed to create Infrastructure: %v", err)
+	}
+
+	region, err := reconciler.getClusterRegion(context.TODO())
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if region != expectedRegion {
+		t.Fatalf("Expected region %s, got: %s", expectedRegion, region)
+	}
+}
+
+// Test_getClusterRegion_NoPlatformStatus validates empty region when PlatformStatus is nil
+func Test_getClusterRegion_NoPlatformStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockReadiness := readiness.NewMockInterface(ctrl)
+	reconciler := createReconciler(t, mockReadiness)
+	createNamespace(reconciler, t)
+
+	infra := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{},
+	}
+
+	err := reconciler.Client.Create(context.TODO(), infra)
+	if err != nil {
+		t.Fatalf("Failed to create Infrastructure: %v", err)
+	}
+
+	region, err := reconciler.getClusterRegion(context.TODO())
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if region != "" {
+		t.Fatalf("Expected empty region, got: %s", region)
+	}
+}
+
 // Test_isManagementCluster_NamespaceScoping validates Infrastructure access works with namespace scoping
 func Test_isManagementCluster_NamespaceScoping(t *testing.T) {
 	tests := []struct {
@@ -2338,9 +2477,9 @@ func Test_parseMCNamespaceConfigMap(t *testing.T) {
 			expectedNamespaces: []string{},
 		},
 		{
-			name:            "Invalid YAML in ConfigMap",
-			configMapExists: true,
-			configMapData:   "This is invalid YAML: [[[",
+			name:               "Invalid YAML in ConfigMap",
+			configMapExists:    true,
+			configMapData:      "This is invalid YAML: [[[",
 			expectedNamespaces: []string{},
 		},
 		{
@@ -2724,4 +2863,3 @@ func Test_validateAlertManagerConfig_InvalidRegexInRoute(t *testing.T) {
 		t.Fatalf("Expected error about invalid regex, got: %v", err)
 	}
 }
-


### PR DESCRIPTION
Dynamically read the cluster region from the Infrastructure CR (PlatformStatus.AWS.Region or PlatformStatus.GCP.Region) and include it as a 'region' field in the PagerDuty details map for all PD receivers.

This enables filtering and routing PagerDuty incidents by the region the cluster is deployed in. The region is cleared under FedRAMP mode, consistent with the handling of cluster_id.

No RBAC or deployment manifest changes are needed — the operator already has get/list/watch access to config.openshift.io/infrastructures and caches the Infrastructure CR for management cluster detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Alertmanager configuration to include cluster region information in PagerDuty notifications for improved alert routing and context.
  * Added FedRAMP compliance safeguards to properly mask sensitive cluster identity data in alert notifications.

* **Tests**
  * Added test coverage for cluster region extraction from AWS and GCP platform configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->