### PR TITLE
Fix e2e PagerDuty receiver tests to poll for operator reconciliation

### DIFF
--- a/test/e2e/configure_alertmanager_operator_tests.go
+++ b/test/e2e/configure_alertmanager_operator_tests.go
@@ -1291,34 +1291,37 @@ Alerts from hosted control plane namespaces will be routed correctly.
 
 	Describe("PagerDuty receiver configuration", func() {
 		It("contains pagerduty receiver when pd-secret exists", func(ctx context.Context) {
-			configBytes, err := utils.GetAlertmanagerConfigBytes(ctx, client, namespace)
-			Expect(err).ShouldNot(HaveOccurred(), "failed to get alertmanager config from secret")
-			cfg, err := utils.ParseConfigMinimal(configBytes)
-			Expect(err).ShouldNot(HaveOccurred(), "failed to parse alertmanager config")
-
-			Expect(utils.ReceiverExists(cfg, "pagerduty")).To(BeTrue(),
-				"config should contain pagerduty receiver when pd-secret exists")
+			Eventually(ctx, func(g Gomega) {
+				configBytes, err := utils.GetAlertmanagerConfigBytes(ctx, client, namespace)
+				g.Expect(err).ShouldNot(HaveOccurred(), "failed to get alertmanager config from secret")
+				cfg, err := utils.ParseConfigMinimal(configBytes)
+				g.Expect(err).ShouldNot(HaveOccurred(), "failed to parse alertmanager config")
+				g.Expect(utils.ReceiverExists(cfg, "pagerduty")).To(BeTrue(),
+					"config should contain pagerduty receiver when pd-secret exists")
+			}, 30*time.Second, 10*time.Second).Should(Succeed())
 		})
 
 		It("contains PagerDuty severity receivers", func(ctx context.Context) {
-			configBytes, err := utils.GetAlertmanagerConfigBytes(ctx, client, namespace)
-			Expect(err).ShouldNot(HaveOccurred(), "failed to get alertmanager config from secret")
-			cfg, err := utils.ParseConfigMinimal(configBytes)
-			Expect(err).ShouldNot(HaveOccurred(), "failed to parse alertmanager config")
-
-			Expect(utils.ReceiverExists(cfg, "make-it-warning")).To(BeTrue(), "config should contain make-it-warning receiver")
-			Expect(utils.ReceiverExists(cfg, "make-it-error")).To(BeTrue(), "config should contain make-it-error receiver")
-			Expect(utils.ReceiverExists(cfg, "make-it-critical")).To(BeTrue(), "config should contain make-it-critical receiver")
+			Eventually(ctx, func(g Gomega) {
+				configBytes, err := utils.GetAlertmanagerConfigBytes(ctx, client, namespace)
+				g.Expect(err).ShouldNot(HaveOccurred(), "failed to get alertmanager config from secret")
+				cfg, err := utils.ParseConfigMinimal(configBytes)
+				g.Expect(err).ShouldNot(HaveOccurred(), "failed to parse alertmanager config")
+				g.Expect(utils.ReceiverExists(cfg, "make-it-warning")).To(BeTrue(), "config should contain make-it-warning receiver")
+				g.Expect(utils.ReceiverExists(cfg, "make-it-error")).To(BeTrue(), "config should contain make-it-error receiver")
+				g.Expect(utils.ReceiverExists(cfg, "make-it-critical")).To(BeTrue(), "config should contain make-it-critical receiver")
+			}, 30*time.Second, 10*time.Second).Should(Succeed())
 		})
 
 		It("has global pagerduty_url set", func(ctx context.Context) {
-			configBytes, err := utils.GetAlertmanagerConfigBytes(ctx, client, namespace)
-			Expect(err).ShouldNot(HaveOccurred(), "failed to get alertmanager config from secret")
-			cfg, err := utils.ParseConfigMinimal(configBytes)
-			Expect(err).ShouldNot(HaveOccurred(), "failed to parse alertmanager config")
-
-			Expect(utils.HasGlobalPagerdutyURL(cfg)).To(BeTrue(),
-				"config should have global.pagerduty_url set when PagerDuty is configured")
+			Eventually(ctx, func(g Gomega) {
+				configBytes, err := utils.GetAlertmanagerConfigBytes(ctx, client, namespace)
+				g.Expect(err).ShouldNot(HaveOccurred(), "failed to get alertmanager config from secret")
+				cfg, err := utils.ParseConfigMinimal(configBytes)
+				g.Expect(err).ShouldNot(HaveOccurred(), "failed to parse alertmanager config")
+				g.Expect(utils.HasGlobalPagerdutyURL(cfg)).To(BeTrue(),
+					"config should have global.pagerduty_url set when PagerDuty is configured")
+			}, 30*time.Second, 10*time.Second).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
## Summary

Add `Eventually` polling (30s timeout, 10s interval) to three PagerDuty receiver tests that previously used one-shot assertions. This prevents flaky failures when the operator hasn't finished reconciling at test time.

## Context

The int e2e failed on a freshly claimed cluster because the operator pod started 12 minutes after the test ran. The test at line 1285 did a single `Expect` with no polling — it checked the Alertmanager config before the operator had reconciled `pd-secret` into it.

The reconciliation tests added in PR #483 already use `Eventually` for the same checks. These foundation tests from PR #481 were missing it.

## Changes

- `"contains pagerduty receiver when pd-secret exists"` — wrapped in `Eventually`
- `"contains PagerDuty severity receivers"` — wrapped in `Eventually`
- `"has global pagerduty_url set"` — wrapped in `Eventually`

All use 30s timeout with 10s polling (3 attempts). If the operator has reconciled, the first check passes immediately.

## Test plan

- [x] `go build --tags=osde2e ./test/e2e/` passes
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of PagerDuty configuration tests by switching to asynchronous verification with periodic retries and polling. This reduces intermittent failures caused by timing delays and makes CI test outcomes more stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->