### PR TITLE
Reapply "SREP-2513: Separate PD and CAD_PD secrets"

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -76,6 +76,8 @@ const (
 
 	secretNamePD = "pd-secret"
 
+	secretNameCADPD = "cad-pd-secret" // #nosec G101
+
 	secretNameDMS = "dms-secret"
 
 	secretNameAlertmanager = "alertmanager-main"
@@ -191,6 +193,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	switch request.Name {
 	case secretNameGoalert:
 	case secretNamePD:
+	case secretNameCADPD:
 	case secretNameDMS:
 	case secretNameAlertmanager:
 	case cmNameOcmAgent:
@@ -1066,6 +1069,7 @@ func (r *SecretReconciler) parseSecrets(reqLogger logr.Logger, secretList *corev
 	// Check for the presence of specific secrets.
 	goalertSecretExists := secretInList(reqLogger, secretNameGoalert, secretList)
 	pagerDutySecretExists := secretInList(reqLogger, secretNamePD, secretList)
+	cadPagerDutySecretExists := secretInList(reqLogger, secretNameCADPD, secretList)
 	snitchSecretExists := secretInList(reqLogger, secretNameDMS, secretList)
 
 	// If a secret exists, add the necessary configs to Alertmanager.
@@ -1076,12 +1080,26 @@ func (r *SecretReconciler) parseSecrets(reqLogger logr.Logger, secretList *corev
 		if clusterReady {
 			reqLogger.Info("INFO: Cluster is ready; configuring Pager Duty")
 			pagerdutyRoutingKey = readSecretKey(r, secretNamePD, namespace, secretKeyPD)
-			cadPagerdutyRoutingKey = readSecretKey(r, secretNamePD, namespace, secretKeyCADPD)
 		} else {
 			reqLogger.Info("INFO: Cluster is not ready; skipping Pager Duty configuration")
 		}
 	} else {
 		reqLogger.Info("INFO: Pager Duty secret does not exist")
+	}
+
+	if cadPagerDutySecretExists {
+		reqLogger.Info("INFO: CAD Pager Duty secret exists")
+		if clusterReady {
+			reqLogger.Info("INFO: Cluster is ready; configuring CAD Pager Duty")
+			cadPagerdutyRoutingKey = readSecretKey(r, secretNameCADPD, namespace, secretKeyCADPD)
+			if cadPagerdutyRoutingKey == "" {
+				reqLogger.Info("INFO: CAD Pager Duty secret exists but configuration is empty")
+			}
+		} else {
+			reqLogger.Info("INFO: Cluster is not ready; skipping CAD Pager Duty configuration")
+		}
+	} else {
+		reqLogger.Info("INFO: CAD Pager Duty secret does not exist")
 	}
 
 	if snitchSecretExists {

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -607,7 +607,8 @@ func Test_parseSecrets(t *testing.T) {
 	gaHeartURL := "https://dummy-gaheartbeat-url"
 
 	createNamespace(reconciler, t)
-	createSecretWithData(reconciler, secretNamePD, map[string]string{secretKeyPD: pdKey, secretKeyCADPD: cadKey})
+	createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
+	createSecret(reconciler, secretNameCADPD, secretKeyCADPD, cadKey)
 	createSecret(reconciler, secretNameDMS, secretKeyDMS, dmsURL)
 	createGoAlertSecret(reconciler,
 		secretNameGoalert,
@@ -647,7 +648,8 @@ func Test_parseSecrets_MissingDMS(t *testing.T) {
 	cadKey := "cadlkj890"
 
 	createNamespace(reconciler, t)
-	createSecretWithData(reconciler, secretNamePD, map[string]string{secretKeyPD: pdKey, secretKeyCADPD: cadKey})
+	createSecret(reconciler, secretNamePD, secretKeyPD, pdKey)
+	createSecret(reconciler, secretNameCADPD, secretKeyCADPD, cadKey)
 
 	secretList := &corev1.SecretList{}
 	err := reconciler.Client.List(context.TODO(), secretList, &client.ListOptions{})


### PR DESCRIPTION
Separates the PD and CAD_PD secrets into distinct secrets (pd-secret and cad-pd-secret) instead of reading both keys from pd-secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PagerDuty routing detection so CAD-specific routing is read from the correct secret when present and the cluster is ready; improved logging for secret presence and readiness states.

* **Tests**
  * Updated test setups to use a unified secret creation helper and validate the corrected detection and handling across initialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->