### PR TITLE
ROSAENG-1342: Replace osd-cluster-ready Job dependency with ClusterOperator check

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Failed validation events include:
 - **Invalid regex patterns**: MatchRE patterns must be valid regular expressions
 
 ## Cluster Readiness
-To avoid alert noise while a cluster is in the early stages of being installed and configured, this operator waits to configure Pager Duty -- effectively silencing alerts -- until a predetermined set of health checks, performed by [osd-cluster-ready](https://github.com/openshift/osd-cluster-ready/), has completed.
+To avoid alert noise while a cluster is in the early stages of being installed and configured, this operator waits to configure Pager Duty -- effectively silencing alerts -- until all ClusterOperators have stopped progressing (`Progressing=false`).
 
-This determination is made through the presence of a completed `Job` named `osd-cluster-ready` in the `openshift-monitoring` namespace.
+As a fallback, if the cluster is older than `MAX_CLUSTER_AGE_MINUTES` (default: 90 minutes), the operator declares the cluster ready regardless of ClusterOperator state. This is measured from the cluster's initial creation time, and since ROSA Classic clusters take ~45 minutes to install, the fallback only fires if ClusterOperators remain unhealthy for ~45 minutes after install completes.
 
 ## Metrics
 The Configure Alertmanager Operator exposes the following Prometheus metrics:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN make go-build
 
 ####
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
 
 ENV USER_UID=1001 \
     USER_NAME=configure-alertmanager-operator

--- a/build/Dockerfile.olm-registry
+++ b/build/Dockerfile.olm-registry
@@ -4,7 +4,7 @@ COPY ${SAAS_OPERATOR_DIR} manifests
 RUN initializer --permissive
 
 # ubi-micro does not work for clusters with fips enabled unless we make OpenSSL available
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1779809423
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
 
 COPY --from=builder /bin/registry-server /bin/registry-server
 COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe

--- a/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/default/ClusterRole-configure-alertmanager-operator-view.yaml
@@ -24,6 +24,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusteroperators
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - proxies
   - infrastructures
   verbs:

--- a/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-view.yaml
+++ b/deploy_pko/.test-fixtures/fedramp/ClusterRole-configure-alertmanager-operator-view.yaml
@@ -24,6 +24,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusteroperators
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - proxies
   - infrastructures
   verbs:

--- a/deploy_pko/ClusterRole-configure-alertmanager-operator-view.yaml.gotmpl
+++ b/deploy_pko/ClusterRole-configure-alertmanager-operator-view.yaml.gotmpl
@@ -24,6 +24,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusteroperators
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - proxies
   - infrastructures
   verbs:

--- a/pkg/readiness/cluster_ready.go
+++ b/pkg/readiness/cluster_ready.go
@@ -13,13 +13,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/openshift/configure-alertmanager-operator/config"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/prometheus/client_golang/api"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -55,97 +52,73 @@ type Interface interface {
 var _ Interface = &Impl{}
 
 const (
-	// Maximum cluster age, in minutes, after whiche we'll assume we don't need to run health checks.
-	maxClusterAgeKey = "MAX_CLUSTER_AGE_MINUTES"
-	// By default, ignore clusters older than two hours
-	maxClusterAgeDefault = 2 * 60
-
-	jobName = "osd-cluster-ready"
+	maxClusterAgeKey     = "MAX_CLUSTER_AGE_MINUTES"
+	maxClusterAgeDefault = 90
 )
 
-// IsReady deals with the osd-cluster-ready Job.
-// Sets:
-//   - impl.Ready:
-//     true if:
-//   - a previous check has already succeeded (a cluster can't become un-ready once it's ready);
-//   - an osd-cluster-ready Job has completed; or
-//   - the cluster is older than maxClusterAgeMinutes
-//     false otherwise.
-//   - impl.Result: If the caller's reconcile is otherwise successful, it
-//     should return the given Result.
-//   - impl.clusterCreationTime: If it is necessary to check the age of the cluster, this is set so
-//     we only have to query prometheus once.
+// IsReady determines whether the cluster is ready for PagerDuty configuration.
+// Ready is true if:
+//   - a previous check has already succeeded (cached);
+//   - all ClusterOperators have Progressing=false; or
+//   - the cluster is older than maxClusterAgeMinutes (fallback)
 func (impl *Impl) IsReady() (bool, error) {
 	if impl.ready {
 		log.Info("DEBUG: Using cached positive cluster readiness.")
 		return impl.ready, nil
 	}
 
-	// Default Result
 	impl.result = reconcile.Result{}
 
-	// Readiness job part 1: Grab it, and short out if it has finished (success or failure).
-	job := &batchv1.Job{}
-	found := true
-	if err := impl.Client.Get(context.TODO(), types.NamespacedName{Namespace: config.OperatorNamespace, Name: jobName}, job); err != nil {
-		if !errors.IsNotFound(err) {
-			// If we couldn't query k8s, it is fatal for this iteration of the reconcile
-			return false, fmt.Errorf("failed to retrieve %s Job: %w", jobName, err)
+	// Primary check: all ClusterOperators have stopped progressing
+	coList := &configv1.ClusterOperatorList{}
+	if err := impl.Client.List(context.TODO(), coList); err != nil {
+		log.Error(err, "Failed to list ClusterOperators, falling through to age check")
+	} else if len(coList.Items) > 0 {
+		allReady := true
+		for _, co := range coList.Items {
+			for _, cond := range co.Status.Conditions {
+				if cond.Type == configv1.OperatorProgressing && cond.Status == configv1.ConditionTrue {
+					allReady = false
+					break
+				}
+				if cond.Type == configv1.OperatorDegraded && cond.Status == configv1.ConditionTrue {
+					allReady = false
+					break
+				}
+				if cond.Type == configv1.OperatorAvailable && cond.Status == configv1.ConditionFalse {
+					allReady = false
+					break
+				}
+			}
+			if !allReady {
+				break
+			}
 		}
-		found = false
-	}
-	// If the job completed, we're done, and we don't need to bother with the age check.
-	if found && job.Status.Active == 0 {
-		var msg string
-		if job.Status.Succeeded > 0 {
-			msg = fmt.Sprintf("INFO: Found a succeeded %s Job.", jobName)
-		} else {
-			msg = fmt.Sprintf("INFO: Found failed %s Job. Declaring ready.", jobName)
+		if allReady {
+			log.Info(fmt.Sprintf("INFO: All %d ClusterOperators are Available, not Progressing, and not Degraded. Cluster is ready.", len(coList.Items)))
+			impl.ready = true
+			return impl.ready, nil
 		}
-		log.Info(msg)
-		impl.ready = true
-		return impl.ready, nil
 	}
 
-	// Cluster age: short out if the cluster is older than the configured value
+	// Fallback: cluster age check
 	if err := impl.setClusterCreationTime(); err != nil {
 		log.Error(err, "Failed to determine cluster creation time")
-		// If we failed to query prometheus, the cluster isn't ready.
-		// We want the main Reconcile loop to proceed, so don't return an error; but
-		// we want to requeue rapidly so we can keep checking for cluster birth.
 		impl.result = reconcile.Result{Requeue: true, RequeueAfter: time.Second}
 		return false, nil
 	}
 	maxClusterAge, err := getEnvInt(maxClusterAgeKey, maxClusterAgeDefault)
 	if err != nil {
-		// This is likely to result in a hot loop :(
 		return false, err
 	}
 	if impl.clusterTooOld(maxClusterAge) {
-		log.Info(fmt.Sprintf("INFO: Cluster is older than %d minutes. Ignoring health check.", maxClusterAge))
+		log.Info(fmt.Sprintf("INFO: Cluster is older than %d minutes. Declaring ready.", maxClusterAge))
 		impl.ready = true
 		return impl.ready, nil
 	}
 
-	// Readiness job part 2: Either the job is still running or doesn't yet exist. We do
-	// these after the age check because they declare "not ready" and requeue, neither of
-	// which we want to do if the cluster is too old.
-
-	if found {
-		// The Job is still running (we checked Active == 0 above).
-		// Requeue with a short delay. We don't want to thrash, but we want to poll the
-		// Job fairly frequently so we configure alerts promptly once it finishes.
-		delay := 10 * time.Second
-		log.Info(fmt.Sprintf("INFO: Found an Active %s Job. Will requeue after %v.", jobName, delay))
-		impl.result = reconcile.Result{Requeue: true, RequeueAfter: delay}
-		return false, nil
-	}
-
-	// The Job doesn't exist -- requeue with a delay and keep looking for it. The delay
-	// here can be longish because the readiness job will take a while to complete once
-	// it does start.
-	delay := 5 * time.Minute
-	log.Info(fmt.Sprintf("INFO: No %s Job found; requeueing after %v to wait for it.", jobName, delay))
+	delay := 30 * time.Second
+	log.Info(fmt.Sprintf("INFO: ClusterOperators still progressing. Requeueing after %v.", delay))
 	impl.result = reconcile.Result{Requeue: true, RequeueAfter: delay}
 	return false, nil
 }
@@ -172,9 +145,9 @@ func (impl *Impl) setPromAPI() error {
 				KeepAlive: 30 * time.Second,
 			}).DialContext,
 			TLSClientConfig: &tls.Config{
-				MinVersion:         tls.VersionTLS12,
-			        // disable "G402 (CWE-295): TLS InsecureSkipVerify set true."
-			        // #nosec G402
+				MinVersion: tls.VersionTLS12,
+				// disable "G402 (CWE-295): TLS InsecureSkipVerify set true."
+				// #nosec G402
 				InsecureSkipVerify: true,
 			},
 			TLSHandshakeTimeout: 10 * time.Second,
@@ -189,7 +162,6 @@ func (impl *Impl) setPromAPI() error {
 }
 
 func (impl *Impl) setClusterCreationTime() error {
-	// Is it cached?
 	if !impl.clusterCreationTime.IsZero() {
 		return nil
 	}
@@ -199,11 +171,7 @@ func (impl *Impl) setClusterCreationTime() error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	when := time.Now()
-	// For testing, do something like this, subtracting the number of hours
-	// since you disabled CVO:
-	// when := time.Now().Add(-32*time.Hour)
-	result, warnings, err := impl.promAPI.Query(ctx, "cluster_version{type=\"initial\"}", when)
+	result, warnings, err := impl.promAPI.Query(ctx, "cluster_version{type=\"initial\"}", time.Now())
 	if err != nil {
 		return fmt.Errorf("error querying Prometheus: %w", err)
 	}
@@ -211,7 +179,6 @@ func (impl *Impl) setClusterCreationTime() error {
 		log.Info(fmt.Sprintf("Warnings: %v\n", warnings))
 	}
 
-	log.Info(fmt.Sprintf("DEBUG: Result of type %s:\n%s\n", result.Type().String(), result.String()))
 	resultVec := result.(model.Vector)
 	earliest := time.Time{}
 	for i := 0; i < resultVec.Len(); i++ {
@@ -233,23 +200,14 @@ func (impl *Impl) clusterTooOld(maxAgeMinutes int) bool {
 	return impl.clusterCreationTime.Before(maxAge)
 }
 
-// getEnvInt returns the integer value of the environment variable with the specified `key`.
-// If the env var is unspecified/empty, the `def` value is returned.
-// The error is non-nil if the env var is nonempty but cannot be parsed as an int.
 func getEnvInt(key string, def int) (int, error) {
-	var intVal int
-	var err error
-
 	strVal := os.Getenv(key)
-
 	if strVal == "" {
-		// Env var unset; use the default
 		return def, nil
 	}
-
-	if intVal, err = strconv.Atoi(strVal); err != nil {
+	intVal, err := strconv.Atoi(strVal)
+	if err != nil {
 		return 0, fmt.Errorf("invalid value for env var: %s=%s (expected int): %v", key, strVal, err)
 	}
-
 	return intVal, nil
 }


### PR DESCRIPTION
## Summary

Replace the `osd-cluster-ready` Job readiness check with a ClusterOperator conditions check. This is the same signal that Hive/CS uses to transition clusters to the `ready` state.

**Before:** CAMO waits for the `osd-cluster-ready` Job (20x30s consecutive health checks, 10+ min minimum) before configuring PagerDuty. Falls back to 2h cluster age timeout.

**After:** CAMO checks all ClusterOperators for `Available=true`, `Progressing=false`, `Degraded=false`. Falls back to 90 min cluster age timeout. No dependency on external Job.

**Timing:** The age fallback is measured from cluster creation time. ROSA Classic clusters take ~45 min to install, so the 90 min fallback gives ~45 min of grace after install for COs to stabilize. In practice, the CO check passes immediately once install completes, so the fallback rarely fires.

**Changes:**
- `pkg/readiness/cluster_ready.go`: Replace Job check with ClusterOperator list/check, set age fallback to 90 min, remove unused imports
- `deploy_pko/ClusterRole-configure-alertmanager-operator-view.yaml.gotmpl`: Add `clusteroperators` to RBAC (get/list/watch)
- `deploy_pko/.test-fixtures/`: Regenerated default and fedramp fixtures
- `build/Dockerfile`, `build/Dockerfile.olm-registry`: Base image tag update from `container-generate`
- `README.md`: Update Cluster Readiness section

This is part of a broader effort to remove the `osd-cluster-ready` Job from managed clusters ([ROSAENG-1342](https://redhat.atlassian.net/browse/ROSAENG-1342)). The Job duplicates what ClusterOperators already validate and caused CI timeouts.

## Test plan

- [x] `make validate` passes locally
- [ ] CI lint/validate/coverage pass
- [ ] Deploy to a staging cluster and verify PD is configured after ClusterOperators stabilize
- [ ] Verify the 90 min age fallback works on clusters where ClusterOperators are slow

Jira: https://redhat.atlassian.net/browse/ROSAENG-1342

[ROSAENG-1342]: https://redhat.atlassian.net/browse/ROSAENG-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ