### PR TITLE
Add firing_json field for structured alert data

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -584,6 +584,7 @@ func createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion string,
 		"num_firing":   `{{ .Alerts.Firing | len }}`,
 		"num_resolved": `{{ .Alerts.Resolved | len }}`,
 		"resolved":     `{{ template "pagerduty.default.instances" .Alerts.Resolved }}`,
+		"firing_json":  `{{ .Alerts.Firing | toJson }}`,
 		"cluster_id":   clusterID,
 		"region":       clusterRegion,
 	}


### PR DESCRIPTION
## Summary
Adds a new `firing_json` field to PagerDuty Details containing JSON-serialized firing alerts.

## Motivation
Downstream consumers like Configuration Anomaly Detection (CAD) currently parse template text to extract Prometheus labels from firing alerts. This requires complex text parsing logic that is fragile and error-prone.

## Changes
- Adds `firing_json` field with `{{ .Alerts.Firing | toJson }}` template to the PagerDuty config details map
- Provides structured alert data including labels, annotations, timestamps, etc.
- Backward compatible — existing fields unchanged

## Benefits
- Eliminates need for text parsing in downstream consumers
- Provides direct access to alert labels (namespace, persistentvolumeclaim, etc.)
- Enables CAD to precisely target investigations without scanning all cluster resources

## Related
- Addresses discussion in https://github.com/openshift/configure-alertmanager-operator/pull/587
- Enables simplification of https://github.com/openshift/configuration-anomaly-detection/pull/873

cc @clcollins @AlexSmithGH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PagerDuty notifications now include the currently firing alerts in JSON format, providing added context for active incidents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->