### PR TITLE
Revert "Add firing_json field for structured alert data"

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -584,7 +584,6 @@ func createPagerdutyConfig(pagerdutyRoutingKey, clusterID, clusterRegion string,
 		"num_firing":   `{{ .Alerts.Firing | len }}`,
 		"num_resolved": `{{ .Alerts.Resolved | len }}`,
 		"resolved":     `{{ template "pagerduty.default.instances" .Alerts.Resolved }}`,
-		"firing_json":  `{{ .Alerts.Firing | toJson }}`,
 		"cluster_id":   clusterID,
 		"region":       clusterRegion,
 	}


### PR DESCRIPTION
This reverts commit 6df10f9ffd3c19d9132bad5090b713b12e181638.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unnecessary firing JSON detail from PagerDuty notifications.
  * PagerDuty configuration details now include the resolved template and cluster metadata without the redundant field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->