### PR TITLE
Migrate from gopkg.in/yaml.v2 to gopkg.in/yaml.v3

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -23,7 +23,7 @@ import (
 	"runtime/debug"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -14,7 +14,7 @@ import (
 	alertmanager "github.com/openshift/configure-alertmanager-operator/pkg/types"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"go.uber.org/mock/gomock"
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.70.0
 	go.uber.org/mock v0.6.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
@@ -24,6 +24,7 @@ require (
 require (
 	github.com/openshift/api v0.0.0-20260615110019-261e3a0546f3
 	github.com/prometheus/alertmanager v0.33.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/pkg/types/alertmanagerconfig.go
+++ b/pkg/types/alertmanagerconfig.go
@@ -3,7 +3,7 @@ package alertmanagerconfig
 import (
 	"fmt"
 
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // PDRegexLP is the regular expression used in Pager Duty for any Layered Product namespaces.
@@ -47,12 +47,12 @@ func (c Config) String() string {
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Config.
-func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	// We want to set c to the defaults and then overwrite it with the input.
-	// To make unmarshal fill the plain data struct rather than calling UnmarshalYAML
+	// To make Decode fill the plain data struct rather than calling UnmarshalYAML
 	// again, we have to hide it using a type indirection.
 	type plain Config
-	if err := unmarshal((*plain)(c)); err != nil {
+	if err := value.Decode((*plain)(c)); err != nil {
 		return err
 	}
 

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/onsi/gomega"
 	amconfig "github.com/prometheus/alertmanager/config"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
## Summary
- Migrate direct dependency from `gopkg.in/yaml.v2` to `gopkg.in/yaml.v3`
- Update `Config.UnmarshalYAML` signature from v2 callback style to v3 `*yaml.Node`
- yaml.v2 remains as an indirect dependency (transitive deps still need it)
- Supersedes #582 (Mintmaker couldn't do this automatically since it requires code changes)

## Test plan
- [ ] All unit tests pass locally (81/81)
- [ ] CI passes (validate, lint, test, coverage, images, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML configuration parsing and validation while preserving existing behavior.
  * Updated end-to-end configuration handling for improved compatibility with the current YAML format.
* **Tests**
  * Updated configuration tests to verify YAML parsing with the newer format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->