### PR TITLE
Add geowa4 (George Adams) to OWNERS as reviewer and approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ reviewers:
 - rosa-staff-engineers
 - srep-functional-team-rocket
 - clcollins
+- geowa4
 - robotmaxtron
 - typeid
 - xiaoyu74
@@ -10,6 +11,7 @@ approvers:
 - rosa-staff-engineers
 - srep-functional-team-rocket
 - clcollins
+- geowa4
 - robotmaxtron
 - typeid
 - xiaoyu74


### PR DESCRIPTION
## Summary
- Add `geowa4` (George Adams) as individual reviewer and approver in OWNERS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project review and approval assignments.
  * No user-facing product functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->