### PR TITLE
Remove osde2e-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
-	// github.com/openshift/api v0.0.1
-	github.com/openshift/osde2e-common v0.0.0-20260618165637-751e0d23bb9d
 	github.com/operator-framework/operator-lib v0.19.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.92.1
 	github.com/prometheus/client_golang v1.23.2
@@ -23,6 +21,8 @@ require (
 
 require (
 	github.com/openshift/api v0.0.0-20260615110019-261e3a0546f3
+	github.com/openshift/client-go v0.0.0-20260603140539-6892dc3e1ffc
+	github.com/openshift/library-go v0.0.0-20260527152424-3ad832f9a5a5
 	github.com/prometheus/alertmanager v0.33.1
 )
 
@@ -102,8 +102,6 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
-	github.com/openshift/client-go v0.0.0-20260603140539-6892dc3e1ffc // indirect
-	github.com/openshift/library-go v0.0.0-20260527152424-3ad832f9a5a5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,8 +240,6 @@ github.com/openshift/client-go v0.0.0-20260603140539-6892dc3e1ffc h1:yCLc/pmoZ4Y
 github.com/openshift/client-go v0.0.0-20260603140539-6892dc3e1ffc/go.mod h1:eqfaEX/V7xHMZ8Mpf72J03RnnY/kEqoZVLpkpjy5p6s=
 github.com/openshift/library-go v0.0.0-20260527152424-3ad832f9a5a5 h1:IPkGTFwKR7Y6/6NNsp681u8Qi/zZGJdY2dySYVTuyyc=
 github.com/openshift/library-go v0.0.0-20260527152424-3ad832f9a5a5/go.mod h1:/HBhy6jm/igWI3Y1vYFwFG3ZCcXmnNsKUT6VBpPyM9A=
-github.com/openshift/osde2e-common v0.0.0-20260618165637-751e0d23bb9d h1:L0AAQ1d3eDeMgNDEiFlZrjdaskZ2pVlZC34rM91iz9Y=
-github.com/openshift/osde2e-common v0.0.0-20260618165637-751e0d23bb9d/go.mod h1:swgg1YIOtSLyz4YYH+IWPNdCC1WEucYrprScwtNFPTI=
 github.com/operator-framework/operator-lib v0.19.0 h1:az6ogYj21rtU0SF9uYctRLyKp2dtlqTsmpfehFy6Ce8=
 github.com/operator-framework/operator-lib v0.19.0/go.mod h1:KxycAjFnHt0DBtHmH3Jm7yHcY5sdrshPKTqM/HKAQ08=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=

--- a/test/e2e/configure_alertmanager_operator_tests.go
+++ b/test/e2e/configure_alertmanager_operator_tests.go
@@ -10,12 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	utils "github.com/openshift/configure-alertmanager-operator/test/e2e/utils"
-	"github.com/openshift/osde2e-common/pkg/clients/openshift"
-	"github.com/openshift/osde2e-common/pkg/clients/prometheus"
 	amconfig "github.com/prometheus/alertmanager/config"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -35,7 +32,7 @@ var _ = Describe("Configure AlertManager Operator", Ordered, func() {
 	var (
 		client           *resources.Resources
 		dynamicClient    dynamic.Interface
-		prom             *prometheus.Client
+		prom             *prometheusClient
 		amClient         *utils.AlertmanagerClient
 		secrets          = []string{"pd-secret", "dms-secret"}
 		serviceAccounts  = []string{"configure-alertmanager-operator"}
@@ -64,11 +61,7 @@ var _ = Describe("Configure AlertManager Operator", Ordered, func() {
 		kubeClient, err := kubernetes.NewForConfig(cfg)
 		Expect(err).ShouldNot(HaveOccurred(), "failed to create kubernetes client")
 
-		// Create openshift client locally for prometheus client setup
-		k8s, err := openshift.New(GinkgoLogr)
-		Expect(err).ShouldNot(HaveOccurred(), "unable to setup openshift client")
-
-		prom, err = prometheus.New(ctx, k8s)
+		prom, err = newPrometheusClient(ctx, cfg)
 		Expect(err).ShouldNot(HaveOccurred(), "unable to setup prometheus client")
 
 		amClient, err = utils.NewAlertmanagerClient(ctx, dynamicClient, kubeClient, cfg)
@@ -275,7 +268,7 @@ POSSIBLE CAUSES:
 	// when the operator cache is scoped to openshift-monitoring namespace
 
 	It("can access ClusterVersion cluster-scoped resource", func(ctx context.Context) {
-		ginkgo.By("Verifying operator can read ClusterVersion despite namespace-scoped cache")
+		By("Verifying operator can read ClusterVersion despite namespace-scoped cache")
 
 		// ClusterVersion is a cluster-scoped resource that the operator needs for:
 		// 1. Getting cluster ID for PagerDuty/DMS integration labels
@@ -403,7 +396,7 @@ ClusterVersion spec: %+v
 	})
 
 	It("can access Proxy cluster-scoped resource", func(ctx context.Context) {
-		ginkgo.By("Verifying operator can read cluster Proxy configuration")
+		By("Verifying operator can read cluster Proxy configuration")
 
 		// Proxy is a cluster-scoped resource that the operator needs for:
 		// 1. Configuring HTTP proxy for external webhooks (PagerDuty, DMS, GoAlert)
@@ -532,7 +525,7 @@ NEXT STEPS:
 	})
 
 	It("can access Infrastructure cluster-scoped resource", func(ctx context.Context) {
-		ginkgo.By("Verifying operator can read Infrastructure and detect cluster type")
+		By("Verifying operator can read Infrastructure and detect cluster type")
 
 		// Infrastructure is a cluster-scoped resource that the operator needs for:
 		// 1. Detecting if cluster is a HyperShift management cluster (hs-mc-*)
@@ -732,7 +725,7 @@ If ConfigMap is intentionally missing, this warning can be ignored.
 	})
 
 	It("operator pod memory usage is within expected limits", func(ctx context.Context) {
-		ginkgo.By("Verifying namespace scoping reduces operator memory footprint")
+		By("Verifying namespace scoping reduces operator memory footprint")
 
 		// With namespace scoping, the operator should use significantly less memory
 		// because it only caches Secrets/ConfigMaps from openshift-monitoring instead
@@ -884,7 +877,7 @@ Current Pod: %s (Age: %s)
 	})
 
 	It("routes alerts for management cluster namespaces when on MC cluster", func(ctx context.Context) {
-		ginkgo.By("Checking if this is a HyperShift Management Cluster")
+		By("Checking if this is a HyperShift Management Cluster")
 
 		// First, determine if this is a management cluster
 		var infra unstructured.Unstructured
@@ -916,7 +909,7 @@ Current Pod: %s (Age: %s)
 		GinkgoLogr.Info("Management Cluster detected - verifying MC namespace routing",
 			"infrastructureName", infraName)
 
-		ginkgo.By("Verifying managed-namespaces ConfigMap exists")
+		By("Verifying managed-namespaces ConfigMap exists")
 
 		var managedNamespacesCM v1.ConfigMap
 		err = client.Get(ctx, "managed-namespaces", namespace, &managedNamespacesCM)
@@ -989,7 +982,7 @@ Error: %v
 
 		GinkgoLogr.Info("managed-namespaces ConfigMap found")
 
-		ginkgo.By("Parsing managed-namespaces ConfigMap for MC namespaces")
+		By("Parsing managed-namespaces ConfigMap for MC namespaces")
 
 		// Check if ConfigMap has the expected key
 		configData, exists := managedNamespacesCM.Data["managed_namespaces.yaml"]
@@ -1090,7 +1083,7 @@ This may result in no MC namespaces being loaded for alert routing.
 			GinkgoLogr.Info("managed-namespaces ConfigMap has ManagementCluster.AdditionalNamespaces section")
 		}
 
-		ginkgo.By("Verifying alertmanager config includes MC namespace routes")
+		By("Verifying alertmanager config includes MC namespace routes")
 
 		var amSecret v1.Secret
 		err = client.Get(ctx, "alertmanager-main", namespace, &amSecret)
@@ -1392,15 +1385,15 @@ Alerts from hosted control plane namespaces will be routed correctly.
 				_ = amClient.ResolveAlerts(ctx, []utils.AlertmanagerV2PostAlert{sourceAlert, targetAlert})
 			})
 
-			ginkgo.By("Injecting synthetic source alert (ClusterOperatorDegraded)")
+			By("Injecting synthetic source alert (ClusterOperatorDegraded)")
 			err := amClient.PostAlerts(ctx, []utils.AlertmanagerV2PostAlert{sourceAlert})
 			Expect(err).NotTo(HaveOccurred(), "failed to post source alert")
 
-			ginkgo.By("Injecting synthetic target alert (ClusterOperatorDown)")
+			By("Injecting synthetic target alert (ClusterOperatorDown)")
 			err = amClient.PostAlerts(ctx, []utils.AlertmanagerV2PostAlert{targetAlert})
 			Expect(err).NotTo(HaveOccurred(), "failed to post target alert")
 
-			ginkgo.By("Verifying ClusterOperatorDown is inhibited via Alertmanager v2 API")
+			By("Verifying ClusterOperatorDown is inhibited via Alertmanager v2 API")
 			Eventually(ctx, func() error {
 				alerts, err := amClient.GetAlertsByName(ctx, "ClusterOperatorDown", "camo-inhibit-test")
 				if err != nil {
@@ -1787,13 +1780,7 @@ Alerts from hosted control plane namespaces will be routed correctly.
 	})
 
 	PIt("can be upgraded", func(ctx context.Context) {
-		log.SetLogger(GinkgoLogr)
-		k8sClient, err := openshift.New(ginkgo.GinkgoLogr)
-		Expect(err).ShouldNot(HaveOccurred(), "unable to setup k8s client")
-
-		ginkgo.By("forcing operator upgrade")
-		err = k8sClient.UpgradeOperator(ctx, operatorName, namespace)
-		Expect(err).NotTo(HaveOccurred(), "operator upgrade failed")
+		Skip("upgrade testing not supported after osde2e-common removal")
 	})
 })
 

--- a/test/e2e/prometheus_helper.go
+++ b/test/e2e/prometheus_helper.go
@@ -1,0 +1,55 @@
+//go:build osde2e
+// +build osde2e
+
+package osde2etests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	routev1client "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/openshift/library-go/test/library/metrics"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type prometheusClient struct {
+	api prometheusv1.API
+}
+
+func newPrometheusClient(ctx context.Context, cfg *rest.Config) (*prometheusClient, error) {
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	routeClient, err := routev1client.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create route client: %w", err)
+	}
+
+	promAPI, err := metrics.NewPrometheusClient(ctx, kubeClient, routeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create prometheus client: %w", err)
+	}
+
+	return &prometheusClient{api: promAPI}, nil
+}
+
+func (c *prometheusClient) InstantQuery(ctx context.Context, query string) (model.Vector, error) {
+	result, _, err := c.api.Query(ctx, query, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+
+	vector, ok := result.(model.Vector)
+	if !ok {
+		return nil, errors.New("failed to convert result to a Vector object")
+	}
+
+	return vector, nil
+}


### PR DESCRIPTION
## Summary

- Replaces `osde2e-common/pkg/clients/openshift` and `osde2e-common/pkg/clients/prometheus` with a local `prometheusClient` helper in `test/e2e/prometheus_helper.go`
- Uses `openshift/library-go/test/library/metrics.NewPrometheusClient` directly (same as osde2e-common does internally)
- Removes the pending upgrade test body (never ran, depended on osde2e-common `UpgradeOperator`)
- Follows the same pattern as cloud-ingress-operator PR #523

The `osde2e-common` dependency pulls in a large transitive dependency tree. The Prow promotion-int job failed today due to a Go proxy transient error downloading `osde2e-common` during `go mod download`. Removing the dependency eliminates this flake vector and speeds up builds.

## Test plan

- [x] `go test ./test/e2e -c --tags=osde2e -o /dev/null` compiles successfully
- [x] `go build .` compiles successfully
- [x] `go mod tidy` removes osde2e-common cleanly
- [ ] CI presubmits pass

Jira: https://redhat.atlassian.net/browse/ROSAENG-60066

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation for Alertmanager and Prometheus integrations.
  * Added more reliable Prometheus query execution and result validation.
  * Standardized test reporting for clearer diagnostics.
  * Upgrade testing is temporarily skipped because the current test environment does not support it.

* **Chores**
  * Updated OpenShift client dependencies to use maintained direct integrations.
  * Removed obsolete testing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->